### PR TITLE
feat: cleanup + lint

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      - name: Publish @calimero/sdk
+      - name: Publish @calimero-network/calimero-sdk-js
         run: cd packages/sdk && pnpm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish @calimero/cli
+      - name: Publish @calimero-network/calimero-cli-js
         run: cd packages/cli && pnpm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/examples/curb-js/src/dmManagement/DmManagement.ts
+++ b/examples/curb-js/src/dmManagement/DmManagement.ts
@@ -43,29 +43,30 @@ export class DmManagement {
     }
 
     if (ownUsername === otherUsername) {
-      return "You cannot invite yourself";
+      return 'You cannot invite yourself';
     }
 
     // Check if DM already exists between these users
     const creatorDms = this.getDMs(creator);
     const inviteeDms = this.getDMs(invitee);
-    
+
     // Check if creator already has a DM with invitee
     const creatorHasDM = creatorDms.some(
-      (dm) => dm.otherIdentityOld === invitee || dm.otherIdentityNew === invitee
+      dm => dm.otherIdentityOld === invitee || dm.otherIdentityNew === invitee
     );
-    
+
     // Check if invitee already has a DM with creator
     const inviteeHasDM = inviteeDms.some(
-      (dm) => dm.otherIdentityOld === creator || dm.otherIdentityNew === creator
+      dm => dm.otherIdentityOld === creator || dm.otherIdentityNew === creator
     );
-    
+
     // Check if contextId already exists
-    const contextIdExists = creatorDms.some((dm) => dm.contextId === contextId) ||
-                           inviteeDms.some((dm) => dm.contextId === contextId);
-    
+    const contextIdExists =
+      creatorDms.some(dm => dm.contextId === contextId) ||
+      inviteeDms.some(dm => dm.contextId === contextId);
+
     if (creatorHasDM || inviteeHasDM || contextIdExists) {
-      return "DM already exists between these users";
+      return 'DM already exists between these users';
     }
 
     const creatorChat: DMChatInfo = {

--- a/examples/curb-js/src/events.ts
+++ b/examples/curb-js/src/events.ts
@@ -1,9 +1,11 @@
-import { Event } from "@calimero/sdk";
+import { Event } from '@calimero/sdk';
 
-import type { UserId, Username } from "./types";
+import type { UserId, Username } from './types';
 
 @Event
 export class UserJoined {
-  constructor(public userId: UserId, public username: Username) {}
+  constructor(
+    public userId: UserId,
+    public username: Username
+  ) {}
 }
-

--- a/examples/curb-js/src/index.ts
+++ b/examples/curb-js/src/index.ts
@@ -1,7 +1,18 @@
-import { emit, env, Init, Logic, State, View, createUnorderedMap, createVector, createLwwRegister, createUnorderedSet } from "@calimero/sdk";
-import { UnorderedMap, UnorderedSet, Vector, LwwRegister } from "@calimero/sdk/collections";
+import {
+  emit,
+  env,
+  Init,
+  Logic,
+  State,
+  View,
+  createUnorderedMap,
+  createVector,
+  createLwwRegister,
+  createUnorderedSet,
+} from '@calimero/sdk';
+import { UnorderedMap, UnorderedSet, Vector, LwwRegister } from '@calimero/sdk/collections';
 
-import { ChannelManager } from "./channelManagement/channelManagement";
+import { ChannelManager } from './channelManagement/channelManagement';
 import {
   ChannelType,
   type ChannelMembershipInput,
@@ -28,9 +39,9 @@ import {
   type ReadDmProps,
   type UpdateDmHashProps,
   type StoredMessage,
-} from "./messageManagement";
-import { isUsernameTaken } from "./utils/members";
-import { UserJoined } from "./events";
+} from './messageManagement';
+import { isUsernameTaken } from './utils/members';
+import { UserJoined } from './events';
 
 @State
 export class CurbChat {
@@ -197,7 +208,7 @@ export class CurbChatLogic extends CurbChat {
     this.members.set(userId, username);
     this.getChannelManager().addUserToDefaultChannels(userId, username);
     emit(new UserJoined(userId, username));
-    return this.wrapResult("User joined chat");
+    return this.wrapResult('User joined chat');
   }
 
   createChannel(rawInput: CreateChannelInput | { input: CreateChannelInput }): string {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "examples/*"
   ],
   "scripts": {
-    "build": "pnpm --filter '@calimero/sdk' --filter '@calimero/cli' build",
+    "build": "pnpm --filter '@calimero-network/calimero-sdk-js' --filter '@calimero-network/calimero-cli-js' build",
     "test": "pnpm -r --if-present test",
     "test:unit": "cd tests/unit && pnpm test",
     "test:integration": "cd tests/integration && pnpm test",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,13 +1,13 @@
-# @calimero/cli
+# @calimero-network/calimero-cli-js
 
 CLI build tools for compiling Calimero applications to WebAssembly.
 
 ## Installation
 
 ```bash
-npm install -g @calimero/cli
+npm install -g @calimero-network/calimero-cli-js
 # or
-pnpm add -g @calimero/cli
+pnpm add -g @calimero-network/calimero-cli-js
 ```
 
 ## First Time Setup

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@calimero/cli",
+  "name": "@calimero-network/calimero-cli-js",
   "version": "0.1.0",
   "description": "CLI build tools for Calimero applications",
   "type": "module",
@@ -19,7 +19,8 @@
     "build": "tsc",
     "clean": "rm -rf lib",
     "test": "jest --passWithNoTests",
-    "install-deps": "bash scripts/install-deps.sh"
+    "install-deps": "bash scripts/install-deps.sh",
+    "prepublishOnly": "pnpm build"
   },
   "keywords": [
     "calimero",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,20 +1,20 @@
-# @calimero/sdk
+# @calimero-network/calimero-sdk-js
 
 Core SDK for building Calimero P2P applications with automatic CRDT-based state synchronization.
 
 ## Installation
 
 ```bash
-npm install @calimero/sdk
+npm install @calimero-network/calimero-sdk-js
 # or
-pnpm add @calimero/sdk
+pnpm add @calimero-network/calimero-sdk-js
 ```
 
 ## Usage
 
 ```typescript
-import { State, Logic, Init, View, createUnorderedMap } from '@calimero/sdk';
-import type { UnorderedMap } from '@calimero/sdk/collections';
+import { State, Logic, Init, View, createUnorderedMap } from '@calimero-network/calimero-sdk-js';
+import type { UnorderedMap } from '@calimero-network/calimero-sdk-js/collections';
 
 @State
 export class MyApp {
@@ -50,7 +50,7 @@ All values, return payloads, and collection snapshots are serialized with Calime
 Use `createPrivateEntry` for node-local data that should not replicate across the network:
 
 ```typescript
-import { createPrivateEntry } from '@calimero/sdk';
+import { createPrivateEntry } from '@calimero-network/calimero-sdk-js';
 
 const secrets = createPrivateEntry<{ token: string }>('private:secrets');
 
@@ -69,7 +69,7 @@ Values are serialized with the same helper as service state, but they are writte
 
 ### Updating the storage shim
 
-`@calimero/sdk` ships a prebuilt `storage_wasm.wasm` that mirrors the Rust `storage-wasm` crate.
+`@calimero-network/calimero-sdk-js` ships a prebuilt `storage_wasm.wasm` that mirrors the Rust `storage-wasm` crate.
 Whenever the Rust runtime or storage crate changes, regenerate the artifact and the C header that
 embeds it. From the repository root:
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@calimero/sdk",
+  "name": "@calimero-network/calimero-sdk-js",
   "version": "0.1.0",
   "description": "Core SDK for building Calimero P2P applications",
   "main": "./lib/index.js",
@@ -41,7 +41,8 @@
     "build": "tsc",
     "clean": "rm -rf lib",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "prepublishOnly": "pnpm build"
   },
   "keywords": [
     "calimero",


### PR DESCRIPTION
# feat: cleanup + lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames SDK/CLI packages to @calimero-network scope and updates build/publish config and docs, with minor lint-only changes in examples.
> 
> - **Publishing/Build**:
>   - Update GitHub Actions workflow to publish `@calimero-network/calimero-sdk-js` and `@calimero-network/calimero-cli-js`.
>   - Adjust root `package.json` build script filters to target new package names.
>   - Add `prepublishOnly` scripts in `packages/sdk` and `packages/cli`.
> - **Packages**:
>   - Rename `packages/sdk` to `@calimero-network/calimero-sdk-js` and `packages/cli` to `@calimero-network/calimero-cli-js` in their `package.json` files.
>   - Update installation/import instructions in `packages/sdk/README.md` and `packages/cli/README.md` to new scope.
> - **Examples**:
>   - Minor linting/formatting in `examples/curb-js` (quote style, arrow functions); no functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2a5031bb84dfd71d7cd6ea49f5add81a2642c69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->