### PR TITLE
feat: add search term option

### DIFF
--- a/examples/curb-js/src/messageManagement/types.ts
+++ b/examples/curb-js/src/messageManagement/types.ts
@@ -61,6 +61,7 @@ export type GetMessagesArgs = {
   parentId?: string | null;
   limit?: number;
   offset?: number;
+  searchTerm?: string | null;
 };
 
 export type ReadMessageProps = {


### PR DESCRIPTION
# feat: add search term option

## Description
Search messages in channels. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds case-insensitive text search and post-filter pagination for message retrieval, with extended `getMessages` input parsing (including `argsJson`) and updated types.
> 
> - **Message retrieval**:
>   - Add optional `searchTerm` to filter messages (case-insensitive) in `MessageManagement.getMessages`.
>   - Apply pagination after filtering and return messages in reverse (most recent first); update `total_count` and `start_position` accordingly.
>   - Introduce `messageMatchesSearch` helper.
> - **API/input handling**:
>   - Extend `CurbChat.getMessages` to accept `{ argsJson: { rawInput, searchTerm } }` and merge via new `extractGetMessagesArgs`.
> - **Types**:
>   - Add `searchTerm?: string | null` to `GetMessagesArgs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 210b8d420a786ee6b4a0f77ceeb341773456393c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->