### PR TITLE
State manager initialization consistency

### DIFF
--- a/packages/sdk/src/__tests__/state-manager.test.ts
+++ b/packages/sdk/src/__tests__/state-manager.test.ts
@@ -80,16 +80,15 @@ describe('StateManager', () => {
       expect(result).toBe(cachedState);
     });
 
-    it('should use explicit state class parameter over decorator-set class', () => {
+    it('should preserve decorator-set class when explicit class differs (first class wins)', () => {
       // Simulate decorator setting state class first
       StateManager.setStateClass(TestState);
 
-      // But load is called with explicit class (from dispatcher)
-      // This should initialize with the explicit class if not already initialized
-      const _result = StateManager.load(AnotherState);
+      // Dispatcher calls load with a different explicit class
+      // The first-initialized class should win (TestState)
+      StateManager.load(AnotherState);
 
-      // In this case, TestState was already set via decorator
-      // So load should still use TestState (since it was initialized first)
+      // TestState was already set via decorator, so it should be preserved
       expect(StateManager.getStateClass()).toBe(TestState);
     });
 

--- a/packages/sdk/src/__tests__/state-manager.test.ts
+++ b/packages/sdk/src/__tests__/state-manager.test.ts
@@ -1,0 +1,183 @@
+/**
+ * StateManager tests
+ *
+ * Tests for consistent StateManager initialization across decorator paths
+ */
+
+import './setup';
+import { StateManager } from '../runtime/state-manager';
+
+// Mock state class
+class TestState {
+  value: string = 'test';
+}
+
+// Another mock state class
+class AnotherState {
+  count: number = 0;
+}
+
+describe('StateManager', () => {
+  beforeEach(() => {
+    // Reset StateManager before each test
+    StateManager.reset();
+  });
+
+  describe('initialize()', () => {
+    it('should initialize with a state class', () => {
+      expect(StateManager.isInitialized()).toBe(false);
+
+      const result = StateManager.initialize(TestState);
+
+      expect(result).toBe(true);
+      expect(StateManager.isInitialized()).toBe(true);
+      expect(StateManager.getStateClass()).toBe(TestState);
+    });
+
+    it('should be idempotent for the same state class', () => {
+      StateManager.initialize(TestState);
+
+      const result = StateManager.initialize(TestState);
+
+      expect(result).toBe(true);
+      expect(StateManager.isInitialized()).toBe(true);
+      expect(StateManager.getStateClass()).toBe(TestState);
+    });
+
+    it('should return false and log warning when initializing with different class', () => {
+      StateManager.initialize(TestState);
+
+      const result = StateManager.initialize(AnotherState);
+
+      expect(result).toBe(false);
+      // Original class should be preserved
+      expect(StateManager.getStateClass()).toBe(TestState);
+    });
+
+    it('should return false for null/undefined state class', () => {
+      expect(StateManager.initialize(null)).toBe(false);
+      expect(StateManager.initialize(undefined)).toBe(false);
+      expect(StateManager.isInitialized()).toBe(false);
+    });
+  });
+
+  describe('setStateClass()', () => {
+    it('should delegate to initialize()', () => {
+      StateManager.setStateClass(TestState);
+
+      expect(StateManager.isInitialized()).toBe(true);
+      expect(StateManager.getStateClass()).toBe(TestState);
+    });
+  });
+
+  describe('load()', () => {
+    it('should return cached state if available', () => {
+      const cachedState = new TestState();
+      StateManager.setCurrent(cachedState);
+
+      const result = StateManager.load();
+
+      expect(result).toBe(cachedState);
+    });
+
+    it('should use explicit state class parameter over decorator-set class', () => {
+      // Simulate decorator setting state class first
+      StateManager.setStateClass(TestState);
+
+      // But load is called with explicit class (from dispatcher)
+      // This should initialize with the explicit class if not already initialized
+      const result = StateManager.load(AnotherState);
+
+      // In this case, TestState was already set via decorator
+      // So load should still use TestState (since it was initialized first)
+      expect(StateManager.getStateClass()).toBe(TestState);
+    });
+
+    it('should initialize with explicit class when not yet initialized', () => {
+      expect(StateManager.isInitialized()).toBe(false);
+
+      // When load is called with explicit class and not initialized
+      StateManager.load(TestState);
+
+      // It should initialize with the explicit class
+      expect(StateManager.isInitialized()).toBe(true);
+      expect(StateManager.getStateClass()).toBe(TestState);
+    });
+
+    it('should return null when no state class is available', () => {
+      const result = StateManager.load();
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('getCurrent() and setCurrent()', () => {
+    it('should get and set current state', () => {
+      const state = new TestState();
+
+      StateManager.setCurrent(state);
+
+      expect(StateManager.getCurrent()).toBe(state);
+    });
+
+    it('should allow setting null', () => {
+      const state = new TestState();
+      StateManager.setCurrent(state);
+
+      StateManager.setCurrent(null);
+
+      expect(StateManager.getCurrent()).toBe(null);
+    });
+  });
+
+  describe('reset()', () => {
+    it('should reset all state', () => {
+      StateManager.initialize(TestState);
+      StateManager.setCurrent(new TestState());
+
+      StateManager.reset();
+
+      expect(StateManager.isInitialized()).toBe(false);
+      expect(StateManager.getStateClass()).toBe(null);
+      expect(StateManager.getCurrent()).toBe(null);
+    });
+  });
+
+  describe('decorator timing scenarios', () => {
+    it('should handle @State decorator before dispatcher load', () => {
+      // Scenario: @State decorator runs first
+      StateManager.setStateClass(TestState);
+
+      // Then dispatcher calls load with same class (from method registry)
+      StateManager.load(TestState);
+
+      // Should be properly initialized
+      expect(StateManager.isInitialized()).toBe(true);
+      expect(StateManager.getStateClass()).toBe(TestState);
+    });
+
+    it('should handle dispatcher load before @State decorator', () => {
+      // Scenario: dispatcher calls load first with explicit class
+      StateManager.load(TestState);
+
+      // Then @State decorator runs
+      StateManager.setStateClass(TestState);
+
+      // Should be properly initialized (idempotent)
+      expect(StateManager.isInitialized()).toBe(true);
+      expect(StateManager.getStateClass()).toBe(TestState);
+    });
+
+    it('should handle dispatcher providing state class when decorator not run', () => {
+      // Scenario: no @State decorator, but dispatcher has state class from registry
+      expect(StateManager.isInitialized()).toBe(false);
+
+      // Dispatcher calls load with explicit class
+      StateManager.load(TestState);
+
+      // Should initialize from explicit class
+      expect(StateManager.isInitialized()).toBe(true);
+      expect(StateManager.getStateClass()).toBe(TestState);
+    });
+  });
+});

--- a/packages/sdk/src/__tests__/state-manager.test.ts
+++ b/packages/sdk/src/__tests__/state-manager.test.ts
@@ -86,7 +86,7 @@ describe('StateManager', () => {
 
       // But load is called with explicit class (from dispatcher)
       // This should initialize with the explicit class if not already initialized
-      const result = StateManager.load(AnotherState);
+      const _result = StateManager.load(AnotherState);
 
       // In this case, TestState was already set via decorator
       // So load should still use TestState (since it was initialized first)

--- a/packages/sdk/src/runtime/dispatcher.ts
+++ b/packages/sdk/src/runtime/dispatcher.ts
@@ -536,7 +536,9 @@ function createLogicDispatcher(
 
     let logicInstance: any;
     try {
-      let state = StateManager.load();
+      // Pass explicit state class to ensure consistent initialization
+      // regardless of decorator execution order
+      let state = StateManager.load(stateCtor);
 
       if (!state && stateCtor) {
         state = new stateCtor();
@@ -611,7 +613,9 @@ function createInitDispatcher(
 
     let state: any;
     try {
-      const existing = StateManager.load();
+      // Pass explicit state class to ensure consistent initialization
+      // regardless of decorator execution order
+      const existing = StateManager.load(stateCtor);
       if (existing) {
         panic('Contract state already initialized');
       }

--- a/packages/sdk/src/runtime/state-manager.ts
+++ b/packages/sdk/src/runtime/state-manager.ts
@@ -9,7 +9,7 @@
  * Usage:
  * - `@State` decorator calls `setStateClass()` (which delegates to `initialize()`)
  * - Dispatcher calls `load(explicitStateClass)` with the state class from method registry
- * - The explicit state class parameter takes precedence, ensuring consistency
+ * - Explicit state class is used to initialize; once set, the first class wins
  */
 
 import * as env from '../env/api';
@@ -83,9 +83,9 @@ export class StateManager {
   /**
    * Loads state from storage.
    *
-   * @param explicitStateClass - Optional explicit state class to use. This takes
-   *                             precedence over the decorator-set class, ensuring
-   *                             consistent behavior regardless of decorator timing.
+   * @param explicitStateClass - Optional explicit state class to initialize with.
+   *                             The registered class remains the source of truth
+   *                             after initialization.
    * @returns The loaded state instance, or null if no state is available
    */
   static load(explicitStateClass?: any): any | null {
@@ -94,14 +94,13 @@ export class StateManager {
       return this.currentState;
     }
 
-    // Use explicit state class if provided, otherwise fall back to decorator-set class
-    // This ensures consistent behavior when dispatcher passes the state class from registry
-    const effectiveStateClass = explicitStateClass || this.stateClass;
-
-    // If explicit class provided and different from current, initialize with it
-    if (explicitStateClass && !this.initialized) {
+    // If explicit class provided, attempt initialization (first class wins)
+    if (explicitStateClass) {
       this.initialize(explicitStateClass);
     }
+
+    // Always use the registered state class after initialization attempt
+    const effectiveStateClass = this.stateClass;
 
     if (effectiveStateClass) {
       try {

--- a/packages/sdk/src/runtime/state-manager.ts
+++ b/packages/sdk/src/runtime/state-manager.ts
@@ -33,7 +33,7 @@ export class StateManager {
    */
   static initialize(stateClass: any): boolean {
     if (!stateClass) {
-      env.log('[state-manager] initialize called with null/undefined stateClass');
+      env.log('[state-manager] initialize called without valid stateClass');
       return false;
     }
 
@@ -150,10 +150,11 @@ export class StateManager {
   /**
    * Resets the StateManager to its initial state.
    *
-   * This is primarily for testing purposes to ensure clean state between tests.
+   * WARNING: This clears all state and should only be used for testing.
    * In production, state should persist across the lifetime of the contract.
    */
   static reset(): void {
+    env.log('[state-manager] WARNING: reset() called - all state cleared');
     this.currentState = null;
     this.stateClass = null;
     this.initialized = false;

--- a/packages/sdk/src/runtime/state-manager.ts
+++ b/packages/sdk/src/runtime/state-manager.ts
@@ -1,7 +1,15 @@
 /**
  * State Manager
  *
- * Handles state persistence and lifecycle
+ * Handles state persistence and lifecycle with consistent initialization.
+ *
+ * Initialization is consolidated to a single, explicit path via the `initialize()`
+ * method. This ensures deterministic behavior regardless of decorator execution order.
+ *
+ * Usage:
+ * - `@State` decorator calls `setStateClass()` (which delegates to `initialize()`)
+ * - Dispatcher calls `load(explicitStateClass)` with the state class from method registry
+ * - The explicit state class parameter takes precedence, ensuring consistency
  */
 
 import * as env from '../env/api';
@@ -10,26 +18,94 @@ import { saveRootState, loadRootState } from './root';
 export class StateManager {
   private static currentState: any = null;
   private static stateClass: any = null;
+  private static initialized: boolean = false;
 
   /**
-   * Sets the current state class
+   * Initializes the StateManager with a state class.
+   *
+   * This is the canonical initialization path. It ensures that:
+   * 1. The state class is set exactly once (idempotent for same class)
+   * 2. Warnings are logged if attempting to set a different class
+   * 3. The initialization state is tracked
+   *
+   * @param stateClass - The state class to use for loading/saving state
+   * @returns true if initialization was successful, false if already initialized with different class
    */
-  static setStateClass(stateClass: any): void {
+  static initialize(stateClass: any): boolean {
+    if (!stateClass) {
+      env.log('[state-manager] initialize called with null/undefined stateClass');
+      return false;
+    }
+
+    if (this.initialized && this.stateClass === stateClass) {
+      // Idempotent: same class, already initialized
+      return true;
+    }
+
+    if (this.initialized && this.stateClass !== stateClass) {
+      // Warning: attempting to initialize with different class
+      env.log(
+        '[state-manager] warning: already initialized with different state class, ignoring new class'
+      );
+      return false;
+    }
+
     this.stateClass = stateClass;
+    this.initialized = true;
+    env.log('[state-manager] initialized with state class');
+    return true;
   }
 
   /**
-   * Loads state from storage
+   * Sets the current state class (called by @State decorator).
+   *
+   * Delegates to `initialize()` to ensure consistent initialization.
+   * This method is kept for backward compatibility with the @State decorator.
    */
-  static load(): any | null {
+  static setStateClass(stateClass: any): void {
+    this.initialize(stateClass);
+  }
+
+  /**
+   * Returns whether the StateManager has been initialized.
+   */
+  static isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  /**
+   * Gets the currently registered state class.
+   */
+  static getStateClass(): any {
+    return this.stateClass;
+  }
+
+  /**
+   * Loads state from storage.
+   *
+   * @param explicitStateClass - Optional explicit state class to use. This takes
+   *                             precedence over the decorator-set class, ensuring
+   *                             consistent behavior regardless of decorator timing.
+   * @returns The loaded state instance, or null if no state is available
+   */
+  static load(explicitStateClass?: any): any | null {
     if (this.currentState) {
       env.log('[state-manager] returning cached state instance');
       return this.currentState;
     }
 
-    if (this.stateClass) {
+    // Use explicit state class if provided, otherwise fall back to decorator-set class
+    // This ensures consistent behavior when dispatcher passes the state class from registry
+    const effectiveStateClass = explicitStateClass || this.stateClass;
+
+    // If explicit class provided and different from current, initialize with it
+    if (explicitStateClass && !this.initialized) {
+      this.initialize(explicitStateClass);
+    }
+
+    if (effectiveStateClass) {
       try {
-        const state = loadRootState(this.stateClass);
+        const state = loadRootState(effectiveStateClass);
         if (state) {
           env.log('[state-manager] restored state from persisted snapshot');
           this.currentState = state;
@@ -70,5 +146,17 @@ export class StateManager {
    */
   static setCurrent(state: any): void {
     this.currentState = state;
+  }
+
+  /**
+   * Resets the StateManager to its initial state.
+   *
+   * This is primarily for testing purposes to ensure clean state between tests.
+   * In production, state should persist across the lifetime of the contract.
+   */
+  static reset(): void {
+    this.currentState = null;
+    this.stateClass = null;
+    this.initialized = false;
   }
 }


### PR DESCRIPTION
# Pull Request

## Description

This refactors the `StateManager` initialization logic to ensure consistency across different execution paths, specifically addressing the varying timing of `@State` decorator execution and implicit state creation in the dispatcher.

The changes consolidate state class initialization into a single, explicit `initialize()` method within `StateManager`. This method is idempotent for the same state class and logs a warning if a different class is attempted after initial setup. The `setStateClass()` method now delegates to `initialize()`, and the dispatcher methods (`createLogicDispatcher`, `createInitDispatcher`) explicitly pass the state constructor to `StateManager.load()`, ensuring the correct state class is used for initialization regardless of decorator timing.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring

## Related Issues

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

### Unit Tests

```bash
pnpm test
```

All 84 SDK unit tests passed, including new tests specifically covering `StateManager` initialization, idempotency, and various decorator timing scenarios.

### Integration Tests

```bash
cd tests/integration && pnpm test
```

Integration tests failed due to the CLI not being built (`Cannot find module '/workspace/packages/cli/lib/cli.js'`), which is unrelated to the changes in `state-manager.ts`.

### Manual Testing

N/A

## Screenshots

N/A

## Additional Notes

**Key changes include:**
*   **`packages/sdk/src/runtime/state-manager.ts`**:
    *   Introduced `initialize(stateClass)` as the canonical, idempotent initialization method.
    *   `setStateClass()` now calls `initialize()`.
    *   `load()` now accepts an optional `explicitStateClass` parameter, which takes precedence for initialization.
    *   Added `isInitialized()`, `getStateClass()`, and `reset()` (for testing).
*   **`packages/sdk/src/runtime/dispatcher.ts`**:
    *   `createLogicDispatcher` and `createInitDispatcher` now pass `stateCtor` to `StateManager.load()`.
*   **`packages/sdk/src/__tests__/state-manager.test.ts`**:
    *   Added new unit tests to validate the consistent initialization behavior and handle different decorator/dispatcher execution orders.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c6be81f-ec0d-49c3-8deb-0e309900238f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c6be81f-ec0d-49c3-8deb-0e309900238f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core runtime state loading/initialization behavior, so mistakes could change which class is used for hydration or when state is considered initialized, but the change is small and covered by new unit tests.
> 
> **Overview**
> Refactors `StateManager` initialization to be deterministic across `@State` decorator and dispatcher execution order by introducing an idempotent `initialize()` path where the *first* state class wins and later mismatches are ignored with a warning.
> 
> Updates the runtime dispatcher to call `StateManager.load(stateCtor)` (for both logic and init dispatch) so state class registration happens consistently even when decorators haven’t run yet, and adds `StateManager` introspection helpers plus a test-only `reset()`.
> 
> Adds a new unit test suite covering initialization idempotency, mismatched state class attempts, `load()` behavior with/without explicit state class, and decorator/dispatcher timing scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d76cf2384779f8fab1f39bf931cd899a05a24380. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->