### PR TITLE
Builder QuickJS cleanup

### DIFF
--- a/packages/cli/builder/builder.c
+++ b/packages/cli/builder/builder.c
@@ -1931,6 +1931,38 @@ void js_add_calimero_host_functions(JSContext *ctx) {
 // This prevents WASI runtime initialization which causes imports
 void _start() {}
 
+// ===========================
+// QuickJS Runtime Cleanup
+// ===========================
+// Static globals for cleanup tracking to ensure cleanup runs even on panic paths.
+//
+// Thread Safety: WASM execution in the Calimero runtime is single-threaded,
+// so no synchronization is needed for these globals. Each method invocation
+// runs sequentially within the same WASM instance.
+//
+// Note: This atexit-based cleanup relies on panic_utf8 eventually triggering
+// process exit (not abort). In WASM environments, the host runtime manages
+// cleanup, but this provides defense-in-depth for scenarios where exit()
+// is called normally or through host panic handling.
+static JSRuntime *g_runtime_for_cleanup = NULL;
+static JSContext *g_context_for_cleanup = NULL;
+static int g_cleanup_registered = 0;
+
+static void cleanup_quickjs_on_exit(void) {
+  JSContext *ctx = g_context_for_cleanup;
+  JSRuntime *rt = g_runtime_for_cleanup;
+
+  g_context_for_cleanup = NULL;
+  g_runtime_for_cleanup = NULL;
+
+  if (ctx) {
+    JS_FreeContext(ctx);
+  }
+  if (rt) {
+    JS_FreeRuntime(rt);
+  }
+}
+
 #define DEFINE_CALIMERO_METHOD(name) \
 __attribute__((used)) \
 __attribute__((visibility("default"))) \
@@ -1939,19 +1971,31 @@ void calimero_method_##name() { \
   char log_buf[256]; \
   snprintf(log_buf, sizeof(log_buf), "[wrapper] %s: start", #name); \
   log_c_string(log_buf); \
+  /* Register cleanup handler once to ensure cleanup on panic paths */ \
+  if (!g_cleanup_registered) { \
+    atexit(cleanup_quickjs_on_exit); \
+    g_cleanup_registered = 1; \
+  } \
   JSRuntime *rt = JS_NewRuntime(); \
   if (!rt) { \
+    /* No cleanup needed - g_runtime_for_cleanup not yet set */ \
     snprintf(log_buf, sizeof(log_buf), "[wrapper] %s: JS_NewRuntime failed", #name); \
     log_c_string(log_buf); \
     return; \
   } \
+  /* Store runtime in global for cleanup on panic */ \
+  g_runtime_for_cleanup = rt; \
   JSContext *ctx = JS_NewCustomContext(rt); \
   if (!ctx) { \
     snprintf(log_buf, sizeof(log_buf), "[wrapper] %s: JS_NewCustomContext failed", #name); \
     log_c_string(log_buf); \
+    /* Clear global before freeing to prevent atexit double-free */ \
+    g_runtime_for_cleanup = NULL; \
     JS_FreeRuntime(rt); \
     return; \
   } \
+  /* Store context in global for cleanup on panic */ \
+  g_context_for_cleanup = ctx; \
 \
   js_add_calimero_host_functions(ctx); \
   snprintf(log_buf, sizeof(log_buf), "[wrapper] %s: host functions wired", #name); \
@@ -1966,11 +2010,8 @@ void calimero_method_##name() { \
     log_c_string(log_buf); \
     JSValue buf_exception = JS_GetException(ctx); \
     calimero_log_exception(ctx, buf_exception, "storage buffer"); \
+    /* Panic is noreturn - atexit handler will cleanup via globals */ \
     calimero_panic_with_exception(ctx, buf_exception); \
-    JS_FreeValue(ctx, buf_exception); \
-    JS_FreeContext(ctx); \
-    JS_FreeRuntime(rt); \
-    __builtin_unreachable(); \
   } \
   JSValue global_obj = JS_GetGlobalObject(ctx); \
   JS_SetPropertyStr(ctx, global_obj, "__CALIMERO_STORAGE_WASM__", storage_bytes); \
@@ -1988,11 +2029,8 @@ void calimero_method_##name() { \
     log_c_string(log_buf); \
     JSValue abi_exception = JS_GetException(ctx); \
     calimero_log_exception(ctx, abi_exception, "ABI string creation"); \
+    /* Panic is noreturn - atexit handler will cleanup via globals */ \
     calimero_panic_with_exception(ctx, abi_exception); \
-    JS_FreeValue(ctx, abi_exception); \
-    JS_FreeContext(ctx); \
-    JS_FreeRuntime(rt); \
-    __builtin_unreachable(); \
   } \
   /* Set as string - JavaScript code will parse it if needed */ \
   /* Note: JS_SetPropertyStr consumes the value reference, so we don't free abi_string */ \
@@ -2007,11 +2045,8 @@ void calimero_method_##name() { \
     log_c_string(log_buf); \
     JSValue load_exception = JS_GetException(ctx); \
     calimero_log_exception(ctx, load_exception, "module load"); \
+    /* Panic is noreturn - atexit handler will cleanup via globals */ \
     calimero_panic_with_exception(ctx, load_exception); \
-    JS_FreeValue(ctx, load_exception); \
-    JS_FreeContext(ctx); \
-    JS_FreeRuntime(rt); \
-    __builtin_unreachable(); \
   } \
   snprintf(log_buf, sizeof(log_buf), "[wrapper] %s: module loaded", #name); \
   log_c_string(log_buf); \
@@ -2032,10 +2067,8 @@ void calimero_method_##name() { \
     log_c_string(log_buf); \
     JSValue prop_exception = JS_GetException(ctx); \
     calimero_log_exception(ctx, prop_exception, "method lookup"); \
+    /* Panic is noreturn - atexit handler will cleanup via globals */ \
     calimero_panic_with_exception(ctx, prop_exception); \
-    JS_FreeValue(ctx, prop_exception); \
-    JS_FreeValue(ctx, mod_obj); \
-    __builtin_unreachable(); \
   } \
 \
   if (!JS_IsFunction(ctx, fun_obj)) { \
@@ -2055,13 +2088,8 @@ void calimero_method_##name() { \
     log_c_string(log_buf); \
     JSValue call_exception = JS_GetException(ctx); \
     calimero_log_exception(ctx, call_exception, "method call"); \
+    /* Panic is noreturn - atexit handler will cleanup via globals */ \
     calimero_panic_with_exception(ctx, call_exception); \
-    JS_FreeValue(ctx, result); \
-    JS_FreeValue(ctx, fun_obj); \
-    JS_FreeValue(ctx, mod_obj); \
-    JS_FreeContext(ctx); \
-    JS_FreeRuntime(rt); \
-    __builtin_unreachable(); \
   } \
 \
   fprintf(stderr, "[dispatcher][builder] completed %s\n", #name); \
@@ -2079,6 +2107,9 @@ void calimero_method_##name() { \
   snprintf(log_buf, sizeof(log_buf), "[wrapper] %s: cleanup", #name); \
   log_c_string(log_buf); \
 \
+  /* Clear globals before cleanup to prevent atexit double-free */ \
+  g_context_for_cleanup = NULL; \
+  g_runtime_for_cleanup = NULL; \
   JS_FreeContext(ctx); \
   JS_FreeRuntime(rt); \
   snprintf(log_buf, sizeof(log_buf), "[wrapper] %s: done", #name); \


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses a resource leak in `packages/cli/builder/builder.c` where the QuickJS runtime and context might not be freed if `JS_Call` throws an exception and `calimero_panic_with_exception` is invoked. The `calimero_panic_with_exception` function is `noreturn`, causing subsequent cleanup code to be skipped.

The fix introduces an `atexit` handler (`cleanup_quickjs_on_exit`) that is registered once per process. This handler uses static global variables (`g_runtime_for_cleanup`, `g_context_for_cleanup`) to track the current QuickJS runtime and context. This ensures that resources are always freed when the process exits, regardless of whether it's a normal exit or a panic path.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

### Unit Tests

Not applicable for this C code change.

### Integration Tests

Not applicable for this C code change.

### Manual Testing

No specific manual testing was performed. The fix addresses a resource leak on panic paths, which is handled by the standard C `atexit` mechanism.

## Screenshots

N/A

## Additional Notes

The `atexit` handler is registered only once per process. The global pointers (`g_runtime_for_cleanup`, `g_context_for_cleanup`) are cleared after a successful normal cleanup to prevent double-free issues if the `atexit` handler were to be called after a successful method execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-b98cff8c-e274-4507-aa18-df8112369e86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b98cff8c-e274-4507-aa18-df8112369e86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level runtime lifecycle/cleanup code; incorrect global tracking or double-free/ordering issues could cause crashes or masked leaks, especially around abnormal termination.
> 
> **Overview**
> Fixes a QuickJS resource leak in the WASM builder wrapper by ensuring the `JSRuntime`/`JSContext` are freed even when `calimero_panic_with_exception` (noreturn) is hit.
> 
> Adds an `atexit`-registered cleanup handler plus global tracking pointers, updates `DEFINE_CALIMERO_METHOD` to set/clear those globals around runtime creation and normal teardown, and removes now-unreachable explicit frees after panic calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2292cbcc702505b579e202775ac97890325f65d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->