### PR TITLE
Cli build shutdown handling

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -25,14 +25,138 @@ interface BuildOptions {
   optimize: boolean;
 }
 
+/**
+ * Known build artifacts that may be created during the build process.
+ * These files will be cleaned up if the build is interrupted.
+ */
+const BUILD_ARTIFACTS = [
+  'abi.json',
+  'abi.h',
+  'state-schema.json',
+  'schema.json',
+  'bundle.js',
+  '__calimero_entry.ts',
+  'methods.c',
+  'methods.h',
+  'code.h',
+  'service.wasm',
+  'service.unoptimized.wasm',
+];
+
+/**
+ * State for tracking active build for cleanup on signal interruption.
+ */
+interface BuildCleanupState {
+  outputDir: string | null;
+  // Using any type for signale instance to avoid complex generic type constraints
+  signaleInstance: ReturnType<typeof createSignaleInstance> | null;
+  isBuilding: boolean;
+}
+
+/**
+ * Creates a Signale instance for build logging.
+ */
+function createSignaleInstance(verbose: boolean) {
+  return new Signale({ scope: 'build', interactive: !verbose });
+}
+
+const buildCleanupState: BuildCleanupState = {
+  outputDir: null,
+  signaleInstance: null,
+  isBuilding: false,
+};
+
+/**
+ * Cleans up build artifacts from the output directory.
+ * Called when the build process is interrupted by a signal.
+ */
+function cleanupBuildArtifacts(): void {
+  const { outputDir, signaleInstance, isBuilding } = buildCleanupState;
+
+  if (!isBuilding || !outputDir) {
+    return;
+  }
+
+  signaleInstance?.warn('\nBuild interrupted, cleaning up artifacts...');
+
+  for (const artifact of BUILD_ARTIFACTS) {
+    const filePath = path.join(outputDir, artifact);
+    try {
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+        if (signaleInstance) {
+          signaleInstance.info(`Removed: ${artifact}`);
+        }
+      }
+    } catch {
+      // Ignore cleanup errors - best effort cleanup
+    }
+  }
+
+  // Reset state after cleanup
+  buildCleanupState.isBuilding = false;
+  buildCleanupState.outputDir = null;
+}
+
+/**
+ * Signal handler for graceful shutdown.
+ * Cleans up build artifacts and exits with appropriate code.
+ */
+function createSignalHandler(signal: NodeJS.Signals): () => void {
+  return () => {
+    cleanupBuildArtifacts();
+    // Exit codes: 128 + signal number (SIGINT=2 -> 130, SIGTERM=15 -> 143)
+    const exitCode = signal === 'SIGINT' ? 130 : 143;
+    process.exit(exitCode);
+  };
+}
+
+// Store signal handlers for cleanup
+let sigintHandler: (() => void) | null = null;
+let sigtermHandler: (() => void) | null = null;
+
+/**
+ * Installs signal handlers for graceful shutdown.
+ * Should be called at the start of the build process.
+ */
+function installSignalHandlers(): void {
+  sigintHandler = createSignalHandler('SIGINT');
+  sigtermHandler = createSignalHandler('SIGTERM');
+  process.on('SIGINT', sigintHandler);
+  process.on('SIGTERM', sigtermHandler);
+}
+
+/**
+ * Removes signal handlers after build completes.
+ * Should be called when the build finishes (success or failure).
+ */
+function removeSignalHandlers(): void {
+  if (sigintHandler) {
+    process.removeListener('SIGINT', sigintHandler);
+    sigintHandler = null;
+  }
+  if (sigtermHandler) {
+    process.removeListener('SIGTERM', sigtermHandler);
+    sigtermHandler = null;
+  }
+}
+
 export async function buildCommand(source: string, options: BuildOptions): Promise<void> {
-  const signale = new Signale({ scope: 'build', interactive: !options.verbose });
+  const signale = createSignaleInstance(options.verbose);
+
+  // Setup output directory path
+  const outputDir = path.dirname(options.output);
+
+  // Initialize cleanup state and install signal handlers
+  buildCleanupState.outputDir = outputDir;
+  buildCleanupState.signaleInstance = signale;
+  buildCleanupState.isBuilding = true;
+  installSignalHandlers();
 
   try {
     signale.await(`Building ${source}...`);
 
     // Ensure output directory exists
-    const outputDir = path.dirname(options.output);
     if (!fs.existsSync(outputDir)) {
       fs.mkdirSync(outputDir, { recursive: true });
     }
@@ -130,9 +254,19 @@ export async function buildCommand(source: string, options: BuildOptions): Promi
     const stats = fs.statSync(options.output);
     const sizeKB = (stats.size / 1024).toFixed(2);
 
+    // Build completed successfully - mark as not building before removing handlers
+    buildCleanupState.isBuilding = false;
+
     signale.success(`Contract built successfully: ${options.output} (${sizeKB} KB)`);
   } catch (error) {
+    // Build failed - clean up artifacts on error to avoid inconsistent state
     signale.error('Build failed:', error);
+    cleanupBuildArtifacts();
     process.exit(1);
+  } finally {
+    // Always remove signal handlers when build completes
+    removeSignalHandlers();
+    buildCleanupState.outputDir = null;
+    buildCleanupState.signaleInstance = null;
   }
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -106,6 +106,8 @@ function resetBuildCleanupState(): void {
   buildCleanupState.outputPath = null;
   buildCleanupState.signaleInstance = null;
   buildCleanupState.preexistingArtifacts.clear();
+  // Also reset reentrancy flag to ensure subsequent builds can run cleanup
+  cleanupInProgress = false;
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Description

Implements graceful shutdown handling in the CLI build process (`packages/cli/src/commands/build.ts`). Previously, interrupting the build (SIGINT/SIGTERM) could leave temporary files in an inconsistent state. This change adds signal handlers to clean up build artifacts from the output directory upon termination, ensuring a consistent state.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

<!-- Link to related issues, e.g., Fixes #123 -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

<!-- Describe the tests you ran and their results -->

### Unit Tests

```bash
pnpm test
```
All 69 existing unit tests pass.

### Integration Tests

```bash
cd tests/integration && pnpm test
```
No integration tests were run, as the change primarily addresses signal handling during build interruption, which is difficult to test automatically in this context.

### Manual Testing

- Verified TypeScript compilation passes.
- Verified ESLint shows no errors in the modified file.
- Verified Prettier formatting.
- Manually tested interrupting the `build` command with `Ctrl+C` to confirm temporary files are removed.

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Additional Notes

Key changes include:
- Introduction of `BUILD_ARTIFACTS` constant for known files to clean.
- `buildCleanupState` object to track the current build's context.
- `cleanupBuildArtifacts()` function to remove artifacts.
- `createSignalHandler()`, `installSignalHandlers()`, and `removeSignalHandlers()` for robust signal management.
- Integration of these handlers into `buildCommand()` to install them at the start, clean up on both failure and interruption, and remove them in a `finally` block.

---
<a href="https://cursor.com/background-agent?bcId=bc-4387a204-75bd-4c57-9dfb-c0743f9b5b3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4387a204-75bd-4c57-9dfb-c0743f9b5b3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CLI process lifecycle (signal handlers, `process.exit`, synchronous file deletion) and could unintentionally delete/retain artifacts if the tracked artifact list or preexisting-file detection is wrong, but scope is limited to the build output directory.
> 
> **Overview**
> Adds **graceful shutdown + cleanup** to the CLI `build` command: installs `SIGINT`/`SIGTERM` handlers that synchronously remove known intermediate build artifacts (and the output file) created during the current run, while preserving any preexisting files.
> 
> Restructures `buildCommand` lifecycle management by tracking build state, deduplicating signal handler registration/removal, cleaning up on build errors, and making post-build size reporting non-fatal after the output has been produced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79ae638b75b2c2a21eca4c21020f5709ae4be1e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->