### PR TITLE
fix: replace deprecated --node-name flag with --node

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,12 +488,12 @@ pnpm add -D @calimero-network/calimero-cli-js
 npx calimero-sdk build src/index.ts -o build/service.wasm
 
 # Deploy to node
-meroctl --node-name <NODE> app install \
+meroctl --node <NODE> app install \
   --path build/service.wasm \
   --context-id <CONTEXT_ID>
 
 # Call methods
-meroctl --node-name <NODE> call \
+meroctl --node <NODE> call \
   --context-id <CONTEXT_ID> \
   --method increment
 ```

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Build & deploy the service bundle:
 
 ```bash
 npx calimero-sdk build src/index.ts -o build/service.wasm
-meroctl --node-name <NODE> app install \
+meroctl --node <NODE> app install \
 --path build/service.wasm \
   --context-id <CONTEXT_ID>
 ```
@@ -172,10 +172,10 @@ meroctl --node-name <NODE> app install \
 Call it:
 
 ```bash
-meroctl --node-name <NODE> call \
+meroctl --node <NODE> call \
   --context-id <CONTEXT_ID> \
 --method increment
-meroctl --node-name <NODE> call \
+meroctl --node <NODE> call \
   --context-id <CONTEXT_ID> \
 --method getCount
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,7 +76,7 @@ npx calimero-sdk build src/index.ts -o build/service.wasm
 ### 4. Deploy the Service
 
 ```bash
-meroctl --node-name node1 app install \
+meroctl --node node1 app install \
   --path build/service.wasm \
   --context-id <YOUR_CONTEXT_ID>
 ```
@@ -85,12 +85,12 @@ meroctl --node-name node1 app install \
 
 ```bash
 # Increment the counter
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method increment
 
 # Get the count
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method getCount
 ```

--- a/examples/access-control/README.md
+++ b/examples/access-control/README.md
@@ -20,7 +20,7 @@ pnpm build
 ## Deploy
 
 ```bash
-meroctl --node-name node1 app install \
+meroctl --node node1 app install \
   --path build/service.wasm \
   --context-id <YOUR_CONTEXT_ID>
 ```
@@ -31,24 +31,24 @@ meroctl --node-name node1 app install \
 
 ```bash
 # Add a member (requires Base58-encoded 32-byte public key)
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method addMember \
   --params '{"publicKeyBase58": "<PUBLIC_KEY_BASE58>"}'
 
 # Check if a key is a member
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method isMember \
   --params '{"publicKeyBase58": "<PUBLIC_KEY_BASE58>"}'
 
 # Get all members
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method getAllMembers
 
 # Remove a member
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method kickMember \
   --params '{"publicKeyBase58": "<PUBLIC_KEY_BASE58>"}'
@@ -58,25 +58,25 @@ meroctl --node-name node1 call \
 
 ```bash
 # Create a child context with an alias
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method createContextChild \
   --params '{"protocol": "near", "applicationIdBase58": "<APP_ID_BASE58>", "alias": "my-child-context"}'
 
 # Resolve an alias to a context ID
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method getChildId \
   --params '{"alias": "my-child-context"}'
 
 # Delete the current context (self-destruct)
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method deleteContextChild \
   --params '{"contextIdBase58": ""}'
 
 # Delete a specific context
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method deleteContextChild \
   --params '{"contextIdBase58": "<TARGET_CONTEXT_ID_BASE58>"}'

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -19,7 +19,7 @@ pnpm build
 ## Deploy
 
 ```bash
-meroctl --node-name node1 app install \
+meroctl --node node1 app install \
   --path build/service.wasm \
   --context-id <YOUR_CONTEXT_ID>
 ```
@@ -28,12 +28,12 @@ meroctl --node-name node1 app install \
 
 ```bash
 # Increment
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method increment
 
 # Get count
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method getCount
 ```

--- a/examples/kv-store/README.md
+++ b/examples/kv-store/README.md
@@ -21,19 +21,19 @@ pnpm build
 
 ```bash
 # Set a value
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method set \
   --args '{"key": "name", "value": "Alice"}'
 
 # Get a value
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method get \
   --args '{"key": "name"}'
 
 # Remove a value
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method remove \
   --args '{"key": "name"}'

--- a/examples/team-metrics/README.md
+++ b/examples/team-metrics/README.md
@@ -20,19 +20,19 @@ pnpm build
 
 ```bash
 # Add contribution
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method addContribution \
   --args '{"member": "alice", "points": 10}'
 
 # Get member metrics
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method getMemberMetrics \
   --args '{"member": "alice"}'
 
 # Get total contributions
-meroctl --node-name node1 call \
+meroctl --node node1 call \
   --context-id <CONTEXT_ID> \
   --method getTotalContributions
 ```


### PR DESCRIPTION
## Summary
- Replace all occurrences of deprecated `--node-name` flag with `--node` in `meroctl` command examples across docs and all example READMEs

## Files changed
- `README.md`
- `AGENTS.md`
- `docs/getting-started.md`
- `examples/kv-store/README.md`
- `examples/team-metrics/README.md`
- `examples/counter/README.md`
- `examples/access-control/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it updates CLI examples to match the current `meroctl` flag and should not affect runtime behavior.
> 
> **Overview**
> Updates documentation and example READMEs to replace deprecated `meroctl --node-name` usage with the current `--node` flag for `app install` and `call` command examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 640e47b51ee3aa0f7ba3b8082883f06782a690b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->