### PR TITLE
feat(sdk): JS root-state merge + deterministic collection ids (concurrent-writer convergence)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,37 +266,17 @@ jobs:
             exit 1
           fi
 
-          # Known-limitation gating (diagnosed in #83):
-          #   * user-storage, frozen-storage: concurrent writes from two nodes.
-          #     A JS root is opaque to core (crdt_type: None) and merges via LWW,
-          #     which converges a single writer but not concurrent writers.
-          #     Fixed by the real JS root-state merge — core#3309 + JS side.
-          #     https://github.com/calimero-network/calimero-sdk-js/issues/83
-          #   * private-data: same convergence issue (#83) PLUS a node-side
-          #     setPrivateNote failure on the joined node — #85.
-          #     https://github.com/calimero-network/calimero-sdk-js/issues/85
-          #   * xcall: distinct functional bug — cross-context pong never
-          #     executes — unrelated to convergence — #84.
-          #     https://github.com/calimero-network/calimero-sdk-js/issues/84
-          SKIP_WORKFLOWS=(
-            "examples/kv-store-with-user-and-frozen-storage/workflows/test_user_storage.yml"
-            "examples/kv-store-with-user-and-frozen-storage/workflows/test_frozen_storage.yml"
-            "examples/private-data/workflows/private-data-js.yml"
-            "examples/xcall/workflows/xcall-js.yml"
-          )
-
+          # All example workflows run — no gating. The concurrent-writer
+          # convergence that previously failed (user-storage, frozen-storage,
+          # private-data, xcall) is fixed by core#3309/#3314/#3315 (JS root as a
+          # ROOT_ENTRY_ID leaf routed through the WASM root merge) plus the JS
+          # SDK's __calimero_merge_root_state + deterministic collection ids and
+          # the persist-then-flush ordering fix (which also cleared the
+          # joined-node StateInconsistency behind #84/#85). See #83.
           WORKFLOW_COUNT=0
           FAILED_WORKFLOWS=()
 
           for workflow in "${WORKFLOW_FILES[@]}"; do
-            skip=false
-            for s in "${SKIP_WORKFLOWS[@]}"; do
-              if [ "$workflow" = "$s" ]; then skip=true; break; fi
-            done
-            if [ "$skip" = true ]; then
-              echo "::notice::Skipping $workflow (concurrent-writer convergence, tracked in #83)"
-              continue
-            fi
             WORKFLOW_COUNT=$((WORKFLOW_COUNT + 1))
             if ! merobox bootstrap run "$workflow" \
                 --e2e-mode \

--- a/packages/cli/builder/builder.c
+++ b/packages/cli/builder/builder.c
@@ -155,6 +155,16 @@ extern int32_t js_frozen_storage_new(uint64_t register_id);
 extern int32_t js_frozen_storage_add(uint64_t storage_id_buffer_ptr, uint64_t value_buffer_ptr, uint64_t register_id);
 extern int32_t js_frozen_storage_get(uint64_t storage_id_buffer_ptr, uint64_t hash_buffer_ptr, uint64_t register_id);
 extern int32_t js_frozen_storage_contains(uint64_t storage_id_buffer_ptr, uint64_t hash_buffer_ptr);
+// Opt-in field-aware root merge + deterministic-id CRDT constructors
+// (concurrent-writer convergence). Provided by the node runtime.
+extern void register_js_sdk_root_merge(void);
+extern int32_t js_crdt_map_new_with_id(uint64_t id_buffer_ptr, uint64_t register_id);
+extern int32_t js_crdt_vector_new_with_id(uint64_t id_buffer_ptr, uint64_t register_id);
+extern int32_t js_crdt_set_new_with_id(uint64_t id_buffer_ptr, uint64_t register_id);
+extern int32_t js_crdt_lww_new_with_id(uint64_t id_buffer_ptr, uint64_t register_id);
+extern int32_t js_crdt_counter_new_with_id(uint64_t id_buffer_ptr, uint64_t register_id);
+extern int32_t js_user_storage_new_with_id(uint64_t id_buffer_ptr, uint64_t register_id);
+extern int32_t js_frozen_storage_new_with_id(uint64_t id_buffer_ptr, uint64_t register_id);
 extern void commit(uint64_t root_hash_buffer_ptr, uint64_t artifact_buffer_ptr);
 extern void persist_root_state(uint64_t doc_buffer_ptr, uint64_t created_at, uint64_t updated_at);
 extern int32_t read_root_state(uint64_t register_id);
@@ -1688,6 +1698,44 @@ static JSValue js_ed25519_verify(JSContext *ctx, JSValueConst this_val, int argc
   return JS_NewBool(ctx, result);
 }
 
+// Wrapper: register_js_sdk_root_merge
+static JSValue js_register_js_sdk_root_merge(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+  register_js_sdk_root_merge();
+  return JS_UNDEFINED;
+}
+
+// Deterministic-id CRDT constructors: (id: Uint8Array, register_id) -> int32
+// Shared body via macro since all seven host functions share the same shape.
+#define DEFINE_NEW_WITH_ID_WRAPPER(wrapper_name, host_fn, label)                       \
+  static JSValue wrapper_name(JSContext *ctx, JSValueConst this_val, int argc,         \
+                              JSValueConst *argv) {                                    \
+    if (argc < 2) {                                                                    \
+      JS_ThrowTypeError(ctx, label " expects id and register id");                     \
+      return JS_EXCEPTION;                                                             \
+    }                                                                                  \
+    size_t id_len;                                                                     \
+    uint8_t *id_ptr = JSValueToUint8Array(ctx, argv[0], &id_len);                      \
+    if (!id_ptr) {                                                                     \
+      JS_ThrowTypeError(ctx, label ": id must be Uint8Array");                         \
+      return JS_EXCEPTION;                                                             \
+    }                                                                                  \
+    int64_t register_id;                                                              \
+    if (js_to_i64(ctx, argv[1], &register_id)) {                                       \
+      return JS_EXCEPTION;                                                             \
+    }                                                                                  \
+    CalimeroBuffer id_buf = make_buffer(id_ptr, id_len);                               \
+    int32_t status = host_fn((uint64_t)&id_buf, (uint64_t)register_id);                \
+    return JS_NewInt32(ctx, status);                                                   \
+  }
+
+DEFINE_NEW_WITH_ID_WRAPPER(js_env_crdt_map_new_with_id, js_crdt_map_new_with_id, "js_crdt_map_new_with_id")
+DEFINE_NEW_WITH_ID_WRAPPER(js_env_crdt_vector_new_with_id, js_crdt_vector_new_with_id, "js_crdt_vector_new_with_id")
+DEFINE_NEW_WITH_ID_WRAPPER(js_env_crdt_set_new_with_id, js_crdt_set_new_with_id, "js_crdt_set_new_with_id")
+DEFINE_NEW_WITH_ID_WRAPPER(js_env_crdt_lww_new_with_id, js_crdt_lww_new_with_id, "js_crdt_lww_new_with_id")
+DEFINE_NEW_WITH_ID_WRAPPER(js_env_crdt_counter_new_with_id, js_crdt_counter_new_with_id, "js_crdt_counter_new_with_id")
+DEFINE_NEW_WITH_ID_WRAPPER(js_env_user_storage_new_with_id, js_user_storage_new_with_id, "js_user_storage_new_with_id")
+DEFINE_NEW_WITH_ID_WRAPPER(js_env_frozen_storage_new_with_id, js_frozen_storage_new_with_id, "js_frozen_storage_new_with_id")
+
 // ===========================
 // Register Host Functions
 // ===========================
@@ -1745,6 +1793,16 @@ void js_add_calimero_host_functions(JSContext *ctx) {
   JS_SetPropertyStr(ctx, env, "js_frozen_storage_add", JS_NewCFunction(ctx, js_env_frozen_storage_add, "js_frozen_storage_add", 3));
   JS_SetPropertyStr(ctx, env, "js_frozen_storage_get", JS_NewCFunction(ctx, js_env_frozen_storage_get, "js_frozen_storage_get", 3));
   JS_SetPropertyStr(ctx, env, "js_frozen_storage_contains", JS_NewCFunction(ctx, js_env_frozen_storage_contains, "js_frozen_storage_contains", 2));
+
+  // Opt-in root merge + deterministic-id CRDT constructors
+  JS_SetPropertyStr(ctx, env, "register_js_sdk_root_merge", JS_NewCFunction(ctx, js_register_js_sdk_root_merge, "register_js_sdk_root_merge", 0));
+  JS_SetPropertyStr(ctx, env, "js_crdt_map_new_with_id", JS_NewCFunction(ctx, js_env_crdt_map_new_with_id, "js_crdt_map_new_with_id", 2));
+  JS_SetPropertyStr(ctx, env, "js_crdt_vector_new_with_id", JS_NewCFunction(ctx, js_env_crdt_vector_new_with_id, "js_crdt_vector_new_with_id", 2));
+  JS_SetPropertyStr(ctx, env, "js_crdt_set_new_with_id", JS_NewCFunction(ctx, js_env_crdt_set_new_with_id, "js_crdt_set_new_with_id", 2));
+  JS_SetPropertyStr(ctx, env, "js_crdt_lww_new_with_id", JS_NewCFunction(ctx, js_env_crdt_lww_new_with_id, "js_crdt_lww_new_with_id", 2));
+  JS_SetPropertyStr(ctx, env, "js_crdt_counter_new_with_id", JS_NewCFunction(ctx, js_env_crdt_counter_new_with_id, "js_crdt_counter_new_with_id", 2));
+  JS_SetPropertyStr(ctx, env, "js_user_storage_new_with_id", JS_NewCFunction(ctx, js_env_user_storage_new_with_id, "js_user_storage_new_with_id", 2));
+  JS_SetPropertyStr(ctx, env, "js_frozen_storage_new_with_id", JS_NewCFunction(ctx, js_env_frozen_storage_new_with_id, "js_frozen_storage_new_with_id", 2));
   
   // Context
   JS_SetPropertyStr(ctx, env, "context_id", JS_NewCFunction(ctx, js_context_id, "context_id", 1));

--- a/packages/cli/src/compiler/methods.ts
+++ b/packages/cli/src/compiler/methods.ts
@@ -28,6 +28,7 @@ export async function generateMethodsHeader(jsFile: string, outputDir: string): 
     registrySnapshot.functions.forEach(fn => methodSet.add(fn));
     methodSet.add('__calimero_sync_next');
     methodSet.add('__calimero_register_merge');
+    methodSet.add('__calimero_merge_root_state');
     emitHeaders(outputDir, Array.from(methodSet).sort());
     return;
   }
@@ -91,6 +92,7 @@ export async function generateMethodsHeader(jsFile: string, outputDir: string): 
 
   methodSet.add('__calimero_sync_next');
   methodSet.add('__calimero_register_merge');
+  methodSet.add('__calimero_merge_root_state');
 
   emitHeaders(outputDir, Array.from(methodSet).sort());
 }

--- a/packages/sdk/src/__tests__/deterministic-id.test.ts
+++ b/packages/sdk/src/__tests__/deterministic-id.test.ts
@@ -1,0 +1,83 @@
+import './setup';
+import { computeCollectionId, computeEntryId, ROOT_ID } from '../utils/deterministic-id';
+import { assignDeterministicIds } from '../runtime/deterministic-ids';
+import { bytesToHex } from '../utils/hex';
+import { UnorderedMap } from '../collections/UnorderedMap';
+import { Vector } from '../collections/Vector';
+
+function toHex(bytes: Uint8Array): string {
+  return bytesToHex(bytes);
+}
+
+describe('deterministic id derivation', () => {
+  it('is stable: the same field path yields the same id', () => {
+    const a = computeCollectionId(ROOT_ID, 'items');
+    const b = computeCollectionId(ROOT_ID, 'items');
+    expect(a.length).toBe(32);
+    expect(toHex(a)).toBe(toHex(b));
+  });
+
+  it('produces distinct ids for distinct field names', () => {
+    const items = computeCollectionId(ROOT_ID, 'items');
+    const notes = computeCollectionId(ROOT_ID, 'notes');
+    expect(toHex(items)).not.toBe(toHex(notes));
+  });
+
+  it('separates collection ids from entry ids (domain separation)', () => {
+    const key = new TextEncoder().encode('items');
+    const collection = computeCollectionId(ROOT_ID, 'items');
+    const entry = computeEntryId(ROOT_ID, key);
+    expect(toHex(collection)).not.toBe(toHex(entry));
+  });
+
+  it('distinguishes parent scope from the null (root-less) scope', () => {
+    const withParent = computeCollectionId(ROOT_ID, 'items');
+    const withoutParent = computeCollectionId(null, 'items');
+    expect(toHex(withParent)).not.toBe(toHex(withoutParent));
+  });
+});
+
+describe('assignDeterministicIds', () => {
+  it('re-opens top-level collection fields at their deterministic id', () => {
+    const state: Record<string, unknown> = {
+      items: new UnorderedMap<string, string>(),
+      log: new Vector<string>(),
+    };
+
+    const itemsRandomId = (state.items as UnorderedMap<string, string>).id();
+    assignDeterministicIds(state);
+
+    const expectedItems = toHex(computeCollectionId(ROOT_ID, 'items'));
+    const expectedLog = toHex(computeCollectionId(ROOT_ID, 'log'));
+
+    expect((state.items as UnorderedMap<string, string>).id()).toBe(expectedItems);
+    expect((state.log as Vector<string>).id()).toBe(expectedLog);
+    // Field was actually re-keyed off its original random id.
+    expect((state.items as UnorderedMap<string, string>).id()).not.toBe(itemsRandomId);
+  });
+
+  it('is idempotent (a second pass leaves ids unchanged)', () => {
+    const state: Record<string, unknown> = { items: new UnorderedMap<string, string>() };
+    assignDeterministicIds(state);
+    const first = (state.items as UnorderedMap<string, string>).id();
+    assignDeterministicIds(state);
+    expect((state.items as UnorderedMap<string, string>).id()).toBe(first);
+  });
+
+  it('two independent nodes derive the same id per logical field', () => {
+    const nodeA: Record<string, unknown> = { notes: new UnorderedMap<string, string>() };
+    const nodeB: Record<string, unknown> = { notes: new UnorderedMap<string, string>() };
+    assignDeterministicIds(nodeA);
+    assignDeterministicIds(nodeB);
+    expect((nodeA.notes as UnorderedMap<string, string>).id()).toBe(
+      (nodeB.notes as UnorderedMap<string, string>).id()
+    );
+  });
+
+  it('ignores non-collection fields', () => {
+    const state: Record<string, unknown> = { owner: 'alice', count: 3 };
+    expect(() => assignDeterministicIds(state)).not.toThrow();
+    expect(state.owner).toBe('alice');
+    expect(state.count).toBe(3);
+  });
+});

--- a/packages/sdk/src/__tests__/merge.test.ts
+++ b/packages/sdk/src/__tests__/merge.test.ts
@@ -1,0 +1,157 @@
+import './setup';
+import { BorshWriter } from '../borsh/encoder';
+import { BorshReader } from '../borsh/decoder';
+import {
+  decodeMergeRootStateRequest,
+  encodeMergeRootStateResponseOk,
+  encodeMergeRootStateResponseErr,
+  computeMergeResponse,
+  mergeField,
+  mergeRootValues,
+  mergeRootCollections,
+  mergeRootMetadata,
+} from '../runtime/merge';
+
+function buildRequest(
+  existing: Uint8Array,
+  incoming: Uint8Array,
+  existingCreatedAt: bigint,
+  existingTs: bigint,
+  incomingTs: bigint
+): Uint8Array {
+  const writer = new BorshWriter();
+  writer.writeBytes(existing);
+  writer.writeBytes(incoming);
+  writer.writeU64(existingCreatedAt);
+  writer.writeU64(existingTs);
+  writer.writeU64(incomingTs);
+  return writer.toBytes();
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+describe('MergeRootStateRequest / Response codec', () => {
+  it('round-trips a request through borsh', () => {
+    const existing = new Uint8Array([1, 2, 3]);
+    const incoming = new Uint8Array([9, 8, 7, 6]);
+    const bytes = buildRequest(existing, incoming, 10n, 20n, 30n);
+
+    const decoded = decodeMergeRootStateRequest(bytes);
+    expect(bytesEqual(decoded.existing, existing)).toBe(true);
+    expect(bytesEqual(decoded.incoming, incoming)).toBe(true);
+    expect(decoded.existingCreatedAt).toBe(10n);
+    expect(decoded.existingTs).toBe(20n);
+    expect(decoded.incomingTs).toBe(30n);
+  });
+
+  it('encodes Ok as [0][vec<u8>]', () => {
+    const payload = new Uint8Array([4, 5, 6]);
+    const encoded = encodeMergeRootStateResponseOk(payload);
+    const reader = new BorshReader(encoded);
+    expect(reader.readU8()).toBe(0);
+    expect(bytesEqual(reader.readBytes(), payload)).toBe(true);
+  });
+
+  it('encodes Err as [1][string]', () => {
+    const encoded = encodeMergeRootStateResponseErr('boom');
+    const reader = new BorshReader(encoded);
+    expect(reader.readU8()).toBe(1);
+    expect(reader.readString()).toBe('boom');
+  });
+});
+
+describe('computeMergeResponse bootstrap fast-path', () => {
+  it('returns Ok(incoming) verbatim when existing_created_at == existing_ts', () => {
+    const existing = new Uint8Array([1, 1, 1]);
+    const incoming = new Uint8Array([2, 2, 2, 2]);
+    // created_at == ts -> existing side created but never written
+    const request = buildRequest(existing, incoming, 42n, 42n, 99n);
+
+    const response = computeMergeResponse(request);
+    const reader = new BorshReader(response);
+    expect(reader.readU8()).toBe(0); // Ok
+    expect(bytesEqual(reader.readBytes(), incoming)).toBe(true);
+  });
+
+  it('does NOT take the fast-path when timestamps differ (falls through to parse)', () => {
+    // existing/incoming are not valid root docs -> parse fails -> Err response,
+    // which proves the fast-path was skipped.
+    const existing = new Uint8Array([1, 1, 1]);
+    const incoming = new Uint8Array([2, 2, 2]);
+    const request = buildRequest(existing, incoming, 42n, 43n, 99n);
+
+    const response = computeMergeResponse(request);
+    const reader = new BorshReader(response);
+    expect(reader.readU8()).toBe(1); // Err (no ABI / invalid doc)
+  });
+});
+
+describe('field-aware value merge', () => {
+  it('keeps equal values', () => {
+    expect(mergeField('x', 'x')).toBe('x');
+  });
+
+  it('prefers a non-default over a default', () => {
+    expect(mergeField('', 'hello')).toBe('hello');
+    expect(mergeField('hello', '')).toBe('hello');
+    expect(mergeField(0n, 5n)).toBe(5n);
+    expect(mergeField(5n, 0n)).toBe(5n);
+  });
+
+  it('is order-independent for two non-default values (converges)', () => {
+    expect(mergeField('apple', 'banana')).toBe(mergeField('banana', 'apple'));
+    expect(mergeField('apple', 'banana')).toBe('banana'); // deterministic byte-order winner
+  });
+
+  it('merges value records deterministically regardless of side', () => {
+    const a = { title: 'A', count: 0n };
+    const b = { title: 'B', count: 7n };
+    const ab = mergeRootValues(a, b);
+    const ba = mergeRootValues(b, a);
+    expect(ab).toEqual(ba);
+    expect(ab.count).toBe(7n); // non-default wins
+  });
+});
+
+describe('collection reference merge', () => {
+  it('unifies refs that share a deterministic id', () => {
+    const local = { items: { type: 'UnorderedMap', id: 'aa'.repeat(32) } };
+    const remote = { items: { type: 'UnorderedMap', id: 'aa'.repeat(32) } };
+    const merged = mergeRootCollections(local, remote);
+    expect(merged.items).toEqual({ type: 'UnorderedMap', id: 'aa'.repeat(32) });
+  });
+
+  it('picks the same ref on both nodes when ids differ (tiebreak)', () => {
+    const idA = 'aa'.repeat(32);
+    const idB = 'bb'.repeat(32);
+    const local = { items: { type: 'UnorderedMap', id: idA } };
+    const remote = { items: { type: 'UnorderedMap', id: idB } };
+    const fromLocal = mergeRootCollections(local, remote);
+    const fromRemote = mergeRootCollections(remote, local);
+    expect(fromLocal).toEqual(fromRemote);
+    expect(fromLocal.items.id).toBe(idA); // lexicographically smaller
+  });
+
+  it('keeps a ref present on only one side', () => {
+    const local = { items: { type: 'UnorderedMap', id: 'aa'.repeat(32) } };
+    const remote = {};
+    const merged = mergeRootCollections(local, remote);
+    expect(merged.items).toEqual({ type: 'UnorderedMap', id: 'aa'.repeat(32) });
+  });
+});
+
+describe('metadata merge', () => {
+  it('takes min(createdAt) and max(updatedAt)', () => {
+    const merged = mergeRootMetadata(
+      { createdAt: 100, updatedAt: 200 },
+      { createdAt: 50, updatedAt: 400 }
+    );
+    expect(merged).toEqual({ createdAt: 50, updatedAt: 400 });
+  });
+});

--- a/packages/sdk/src/__tests__/setup.ts
+++ b/packages/sdk/src/__tests__/setup.ts
@@ -191,10 +191,59 @@ function getExecutorKey(executor?: Uint8Array): string {
   blob_write: (_fd: bigint, data: Uint8Array): bigint => BigInt(data.length),
   blob_close: (_fd: bigint, _blob_id_buf: Uint8Array): boolean => true,
 
+  register_js_sdk_root_merge: (): void => {
+    // no-op in tests
+  },
+
   js_crdt_map_new: (_register_id: bigint): number => {
     const id = generateId();
     maps.set(idToKey(id), { entries: new Map() });
     setRegister(id);
+    return 1;
+  },
+
+  // Deterministic-id constructors: register a backing store at the supplied id.
+  js_crdt_map_new_with_id: (id: Uint8Array, _register_id: bigint): number => {
+    maps.set(idToKey(id), { entries: new Map() });
+    setRegister(new Uint8Array(id));
+    return 1;
+  },
+
+  js_crdt_vector_new_with_id: (id: Uint8Array, _register_id: bigint): number => {
+    vectors.set(idToKey(id), { values: [] });
+    setRegister(new Uint8Array(id));
+    return 1;
+  },
+
+  js_crdt_set_new_with_id: (id: Uint8Array, _register_id: bigint): number => {
+    sets.set(idToKey(id), { values: new Set() });
+    setRegister(new Uint8Array(id));
+    return 1;
+  },
+
+  js_crdt_lww_new_with_id: (id: Uint8Array, _register_id: bigint): number => {
+    lwwRegisters.set(idToKey(id), {
+      value: null,
+      timestamp: 0n,
+      nodeId: mockExecutorId.slice(0, 16),
+    });
+    setRegister(new Uint8Array(id));
+    return 1;
+  },
+
+  js_crdt_counter_new_with_id: (id: Uint8Array, _register_id: bigint): number => {
+    counters.set(idToKey(id), { totalsByExecutor: new Map() });
+    setRegister(new Uint8Array(id));
+    return 1;
+  },
+
+  js_user_storage_new_with_id: (id: Uint8Array, _register_id: bigint): number => {
+    setRegister(new Uint8Array(id));
+    return 1;
+  },
+
+  js_frozen_storage_new_with_id: (id: Uint8Array, _register_id: bigint): number => {
+    setRegister(new Uint8Array(id));
     return 1;
   },
 

--- a/packages/sdk/src/env/api.ts
+++ b/packages/sdk/src/env/api.ts
@@ -539,8 +539,63 @@ export function storageRemove(key: Uint8Array): boolean {
   return existed;
 }
 
+/**
+ * Opt into JS SDK field-aware root-state merge.
+ *
+ * Signals the host that this app root should be merged via the guest
+ * `__calimero_merge_root_state` export on sync instead of being LWW-collapsed.
+ */
+export function registerJsSdkRootMerge(): void {
+  const host = env as unknown as { register_js_sdk_root_merge?: () => void };
+  if (typeof host.register_js_sdk_root_merge !== 'function') {
+    throw new Error('register_js_sdk_root_merge host function unavailable');
+  }
+  host.register_js_sdk_root_merge();
+}
+
+/**
+ * Returns raw bytes to the host verbatim (no JSON/ABI encoding).
+ *
+ * Used by `__calimero_merge_root_state`, which must return a borsh-encoded
+ * response rather than a JSON method return value.
+ */
+export function valueReturnRaw(value: Uint8Array): void {
+  if (!(value instanceof Uint8Array)) {
+    throw new TypeError('valueReturnRaw expects a Uint8Array');
+  }
+  env.value_return(value);
+}
+
 export function jsCrdtMapNew(register: bigint): number {
   return env.js_crdt_map_new(register);
+}
+
+export function jsCrdtMapNewWithId(id: Uint8Array, register: bigint): number {
+  return env.js_crdt_map_new_with_id(id, register);
+}
+
+export function jsCrdtVectorNewWithId(id: Uint8Array, register: bigint): number {
+  return env.js_crdt_vector_new_with_id(id, register);
+}
+
+export function jsCrdtSetNewWithId(id: Uint8Array, register: bigint): number {
+  return env.js_crdt_set_new_with_id(id, register);
+}
+
+export function jsCrdtLwwNewWithId(id: Uint8Array, register: bigint): number {
+  return env.js_crdt_lww_new_with_id(id, register);
+}
+
+export function jsCrdtCounterNewWithId(id: Uint8Array, register: bigint): number {
+  return env.js_crdt_counter_new_with_id(id, register);
+}
+
+export function jsUserStorageNewWithId(id: Uint8Array, register: bigint): number {
+  return env.js_user_storage_new_with_id(id, register);
+}
+
+export function jsFrozenStorageNewWithId(id: Uint8Array, register: bigint): number {
+  return env.js_frozen_storage_new_with_id(id, register);
 }
 
 export function jsCrdtMapGet(mapId: Uint8Array, key: Uint8Array, register: bigint): number {

--- a/packages/sdk/src/env/bindings.ts
+++ b/packages/sdk/src/env/bindings.ts
@@ -19,6 +19,22 @@ export interface HostEnv {
   storage_write(key: Uint8Array, value: Uint8Array, register_id: bigint): bigint;
   storage_remove(key: Uint8Array, register_id: bigint): bigint;
   xcall(context_id: Uint8Array, function_name: Uint8Array, params: Uint8Array): void;
+
+  // Opt-in JS SDK root-state merge. When the guest calls this, core stamps the
+  // app root non-opaque so on sync it is routed to `__calimero_merge_root_state`
+  // (field-aware) instead of being LWW-collapsed.
+  register_js_sdk_root_merge(): void;
+
+  // Deterministic-id CRDT constructors (concurrent-writer convergence):
+  // create/re-open a collection at a caller-supplied 32-byte id.
+  js_crdt_map_new_with_id(id: Uint8Array, register_id: bigint): number;
+  js_crdt_vector_new_with_id(id: Uint8Array, register_id: bigint): number;
+  js_crdt_set_new_with_id(id: Uint8Array, register_id: bigint): number;
+  js_crdt_lww_new_with_id(id: Uint8Array, register_id: bigint): number;
+  js_crdt_counter_new_with_id(id: Uint8Array, register_id: bigint): number;
+  js_user_storage_new_with_id(id: Uint8Array, register_id: bigint): number;
+  js_frozen_storage_new_with_id(id: Uint8Array, register_id: bigint): number;
+
   js_crdt_map_new(register_id: bigint): number;
   js_crdt_map_get(mapId: Uint8Array, key: Uint8Array, register_id: bigint): number;
   js_crdt_map_insert(

--- a/packages/sdk/src/runtime/deterministic-ids.ts
+++ b/packages/sdk/src/runtime/deterministic-ids.ts
@@ -1,0 +1,83 @@
+/**
+ * Deterministic id assignment for top-level `@State` collection fields.
+ *
+ * Collections instantiated in a state-class constructor get a *random* id from
+ * the host `*_new` functions. For concurrent-writer convergence, two nodes must
+ * address the same CRDT entity for the same logical field, so after fresh state
+ * construction we re-open each top-level collection field at a deterministic id
+ * derived from its field name (via the host `*_new_with_id` functions).
+ *
+ * This runs only on fresh state (init / first-use), where collections are still
+ * empty, so re-opening at a new id cannot lose data. On subsequent loads the id
+ * is restored from the persisted snapshot, and re-running is a cheap no-op
+ * because the id already matches.
+ */
+
+import * as env from '../env/api';
+import { bytesToHex } from '../utils/hex';
+import { computeCollectionId, ROOT_ID } from '../utils/deterministic-id';
+import { snapshotCollection, instantiateCollection } from './collections';
+import {
+  mapNewWithId,
+  vectorNewWithId,
+  setNewWithId,
+  lwwNewWithId,
+  counterNewWithId,
+  userStorageNewWithId,
+  frozenStorageNewWithId,
+} from './storage-wasm';
+
+type WithIdFn = (id: Uint8Array) => Uint8Array;
+
+const WITH_ID: Record<string, WithIdFn> = {
+  UnorderedMap: mapNewWithId,
+  Vector: vectorNewWithId,
+  UnorderedSet: setNewWithId,
+  LwwRegister: lwwNewWithId,
+  Counter: counterNewWithId,
+  UserStorage: userStorageNewWithId,
+  FrozenStorage: frozenStorageNewWithId,
+};
+
+/**
+ * Re-open every top-level collection field of {@link state} at a deterministic
+ * id derived from its field name. Idempotent: fields already at the expected id
+ * are skipped.
+ */
+export function assignDeterministicIds(state: unknown): void {
+  if (!state || typeof state !== 'object') {
+    return;
+  }
+
+  const target = state as Record<string, unknown>;
+  for (const key of Object.keys(target)) {
+    const value = target[key];
+
+    const snapshot = snapshotCollection(value);
+    if (!snapshot) {
+      continue;
+    }
+
+    const withId = WITH_ID[snapshot.type];
+    if (!withId) {
+      // Unknown/unsupported collection type — leave it untouched.
+      continue;
+    }
+
+    const expectedId = computeCollectionId(ROOT_ID, key);
+    const expectedHex = bytesToHex(expectedId);
+    if (snapshot.id === expectedHex) {
+      // Already at the deterministic id (e.g. hydrated from a prior snapshot).
+      continue;
+    }
+
+    // Create/re-open the entity at the deterministic id in the host, then swap
+    // the field to a collection wrapping that id. The previous random-id entity
+    // is orphaned (safe: fresh collections are empty).
+    withId(expectedId);
+    target[key] = instantiateCollection({ type: snapshot.type, id: expectedHex });
+    env.log(
+      `[deterministic-ids] field '${key}' (${snapshot.type}) -> ${expectedHex.slice(0, 16)}…`
+    );
+  }
+}

--- a/packages/sdk/src/runtime/dispatcher.ts
+++ b/packages/sdk/src/runtime/dispatcher.ts
@@ -5,10 +5,10 @@ import { getAbiManifest, getMethod } from '../abi/helpers';
 import type { TypeRef, AbiManifest, ScalarType, Variant } from '../abi/types';
 import { registerJsSdkRootMerge } from '../env/api';
 import { assignDeterministicIds } from './deterministic-ids';
+// Importing `registerMergeTypes` also runs ./merge's side effects, which
+// install globalThis.__calimero_merge_root_state (the field-aware root merge).
 import { registerMergeTypes } from './merge';
 import './sync';
-// Installs globalThis.__calimero_merge_root_state (field-aware root merge).
-import './merge';
 
 type JsonObject = Record<string, unknown>;
 

--- a/packages/sdk/src/runtime/dispatcher.ts
+++ b/packages/sdk/src/runtime/dispatcher.ts
@@ -579,11 +579,18 @@ function createLogicDispatcher(
       const result = logicInstance[methodName](...args);
 
       if (isMutating) {
-        // Flush CRDT delta changes to host storage
-        // This generates the delta that includes collection changes
-        flushDelta();
-        // Save state after flushing delta to ensure consistency
+        // Persist the root document FIRST, then flush the causal delta — the
+        // same order the @Init path uses. `StateManager.save()` writes the root
+        // doc (scalar fields + collection refs) via `persist_root_state`, which
+        // emits the root entity's storage action; `flushDelta()` then commits
+        // ALL pending actions (collection ops + that root action) into the delta
+        // the host broadcasts. The previous order (flush then save) left the
+        // root-doc change out of the delta, so a method that touched only the
+        // root doc — or persisted an unchanged doc on a joined node after a
+        // merge — produced `root_hash = Some` with an empty artifact, which the
+        // node rejects as `StateInconsistency` (the #84/#85 node-2 failures).
         StateManager.save(logicInstance);
+        flushDelta();
       }
 
       if (result !== undefined) {

--- a/packages/sdk/src/runtime/dispatcher.ts
+++ b/packages/sdk/src/runtime/dispatcher.ts
@@ -3,15 +3,36 @@ import { StateManager } from './state-manager';
 import { runtimeLogicEntries } from './method-registry';
 import { getAbiManifest, getMethod } from '../abi/helpers';
 import type { TypeRef, AbiManifest, ScalarType, Variant } from '../abi/types';
+import { registerJsSdkRootMerge } from '../env/api';
+import { assignDeterministicIds } from './deterministic-ids';
+import { registerMergeTypes } from './merge';
 import './sync';
+// Installs globalThis.__calimero_merge_root_state (field-aware root merge).
+import './merge';
 
 type JsonObject = Record<string, unknown>;
 
 const REGISTER_ID = 0n;
 
-if (typeof (globalThis as any).__calimero_register_merge !== 'function') {
-  (globalThis as any).__calimero_register_merge = function __calimero_register_merge(): void {};
-}
+/**
+ * `__calimero_register_merge` opt-in hook.
+ *
+ * Registers `@Mergeable` descriptors and signals the host that this app root
+ * should be merged field-aware via `__calimero_merge_root_state` on sync
+ * (instead of being LWW-collapsed). Called by the host at module registration.
+ */
+(globalThis as any).__calimero_register_merge = function __calimero_register_merge(): void {
+  try {
+    registerMergeTypes();
+  } catch (error) {
+    log(`[dispatcher] register_merge: descriptor registration failed: ${String(error)}`);
+  }
+  try {
+    registerJsSdkRootMerge();
+  } catch (error) {
+    log(`[dispatcher] register_merge: register_js_sdk_root_merge failed: ${String(error)}`);
+  }
+};
 
 /**
  * Converts a JSON value to ABI-compatible format
@@ -540,6 +561,9 @@ function createLogicDispatcher(
 
       if (!state && stateCtor) {
         state = new stateCtor();
+        // Fresh (unpersisted) state: normalize top-level collection field ids
+        // to deterministic values so concurrent writers converge.
+        assignDeterministicIds(state);
       }
 
       if (state) {
@@ -624,6 +648,10 @@ function createInitDispatcher(
       if (logicCtor && state instanceof logicCtor === false) {
         Object.setPrototypeOf(state, logicCtor.prototype);
       }
+
+      // Fresh init: assign deterministic ids to top-level collection fields so
+      // concurrent writers on different nodes address the same CRDT entities.
+      assignDeterministicIds(state);
 
       StateManager.save(state);
       flushDelta();

--- a/packages/sdk/src/runtime/merge.ts
+++ b/packages/sdk/src/runtime/merge.ts
@@ -1,0 +1,264 @@
+/**
+ * Field-aware root-state merge (concurrent-writer convergence).
+ *
+ * A JS app root is opaque to core, so two concurrent writers would otherwise
+ * diverge (last-writer-wins collapse). When the guest opts in via
+ * `register_js_sdk_root_merge()` (see dispatcher), core routes the root to the
+ * `__calimero_merge_root_state` export defined here on every sync.
+ *
+ * Calling convention (must match core exactly):
+ *   Input  (register 0): borsh `MergeRootStateRequest`
+ *     { existing: Vec<u8>, incoming: Vec<u8>,
+ *       existing_created_at: u64, existing_ts: u64, incoming_ts: u64 }
+ *   Output (valueReturn): borsh `MergeRootStateResponse` enum
+ *     variant 0 = Ok(Vec<u8>)  -> merged root-doc bytes
+ *     variant 1 = Err(String)
+ *
+ * Bootstrap fast-path: if `existing_created_at == existing_ts` the existing
+ * side was created but never written, so the incoming doc is returned verbatim.
+ */
+
+import * as env from '../env/api';
+import { BorshWriter } from '../borsh/encoder';
+import { BorshReader } from '../borsh/decoder';
+import { serialize } from '../utils/serialize';
+import { parseRootDocument, serializeRootDocument, type RootDocument } from './root';
+import type { CollectionSnapshot } from './collections';
+import { mergeMergeableValues } from './mergeable';
+import { getMergeableType, mergeableTypeCount } from './mergeable-registry';
+
+const REGISTER_ID = 0n;
+
+export interface MergeRootStateRequest {
+  existing: Uint8Array;
+  incoming: Uint8Array;
+  existingCreatedAt: bigint;
+  existingTs: bigint;
+  incomingTs: bigint;
+}
+
+// --- Request / response codec (borsh) ------------------------------------
+
+export function decodeMergeRootStateRequest(bytes: Uint8Array): MergeRootStateRequest {
+  const reader = new BorshReader(bytes);
+  const existing = reader.readBytes();
+  const incoming = reader.readBytes();
+  const existingCreatedAt = reader.readU64();
+  const existingTs = reader.readU64();
+  const incomingTs = reader.readU64();
+  return { existing, incoming, existingCreatedAt, existingTs, incomingTs };
+}
+
+export function encodeMergeRootStateResponseOk(bytes: Uint8Array): Uint8Array {
+  const writer = new BorshWriter();
+  writer.writeU8(0); // Ok
+  writer.writeBytes(bytes);
+  return writer.toBytes();
+}
+
+export function encodeMergeRootStateResponseErr(message: string): Uint8Array {
+  const writer = new BorshWriter();
+  writer.writeU8(1); // Err
+  writer.writeString(message);
+  return writer.toBytes();
+}
+
+// --- Field-aware merge ----------------------------------------------------
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function compareBytes(a: Uint8Array, b: Uint8Array): number {
+  const min = Math.min(a.length, b.length);
+  for (let i = 0; i < min; i += 1) {
+    if (a[i] !== b[i]) {
+      return a[i] - b[i];
+    }
+  }
+  return a.length - b.length;
+}
+
+function isDefaultValue(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return true;
+  }
+  if (value === 0 || value === 0n || value === '' || value === false) {
+    return true;
+  }
+  if (value instanceof Map) {
+    return value.size === 0;
+  }
+  if (value instanceof Set) {
+    return value.size === 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  return false;
+}
+
+/**
+ * Merge a single plain (non-collection) state field.
+ *
+ * Mergeable values fold via their descriptor; everything else is scalar LWW:
+ * equal -> keep; one side default -> take the non-default; otherwise a
+ * deterministic byte-order tiebreak so both nodes converge on the same result.
+ */
+export function mergeField(local: unknown, remote: unknown): unknown {
+  const mergeableType = getMergeableType(remote) ?? getMergeableType(local);
+  if (mergeableType) {
+    return mergeMergeableValues(local, remote);
+  }
+
+  const localBytes = serialize(local);
+  const remoteBytes = serialize(remote);
+  if (bytesEqual(localBytes, remoteBytes)) {
+    return local;
+  }
+
+  const localDefault = isDefaultValue(local);
+  const remoteDefault = isDefaultValue(remote);
+  if (localDefault && !remoteDefault) {
+    return remote;
+  }
+  if (remoteDefault && !localDefault) {
+    return local;
+  }
+
+  return compareBytes(localBytes, remoteBytes) >= 0 ? local : remote;
+}
+
+export function mergeRootValues(
+  local: Record<string, unknown> | undefined,
+  remote: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  const keys = Array.from(new Set([...Object.keys(local ?? {}), ...Object.keys(remote ?? {})]));
+  keys.sort();
+  const result: Record<string, unknown> = {};
+  for (const key of keys) {
+    result[key] = mergeField(local?.[key], remote?.[key]);
+  }
+  return result;
+}
+
+/**
+ * Pick a single collection reference. Equal ids (the deterministic-id case)
+ * unify to the same entity; unequal ids fall back to the lexicographically
+ * smaller id so both nodes agree.
+ */
+function pickCollection(
+  local: CollectionSnapshot | undefined,
+  remote: CollectionSnapshot | undefined
+): CollectionSnapshot | null {
+  if (local && remote) {
+    if (local.id === remote.id) {
+      return local;
+    }
+    return local.id < remote.id ? local : remote;
+  }
+  return local ?? remote ?? null;
+}
+
+export function mergeRootCollections(
+  local: Record<string, CollectionSnapshot> | undefined,
+  remote: Record<string, CollectionSnapshot> | undefined
+): Record<string, CollectionSnapshot> {
+  const keys = Array.from(new Set([...Object.keys(local ?? {}), ...Object.keys(remote ?? {})]));
+  keys.sort();
+  const result: Record<string, CollectionSnapshot> = {};
+  for (const key of keys) {
+    const chosen = pickCollection(local?.[key], remote?.[key]);
+    if (chosen) {
+      result[key] = { type: chosen.type, id: chosen.id };
+    }
+  }
+  return result;
+}
+
+export function mergeRootMetadata(
+  local: { createdAt: number; updatedAt: number },
+  remote: { createdAt: number; updatedAt: number }
+): { createdAt: number; updatedAt: number } {
+  return {
+    createdAt: Math.min(local.createdAt, remote.createdAt),
+    updatedAt: Math.max(local.updatedAt, remote.updatedAt),
+  };
+}
+
+export function mergeRootDocuments(existing: RootDocument, incoming: RootDocument): RootDocument {
+  return {
+    values: mergeRootValues(existing.values, incoming.values),
+    collections: mergeRootCollections(existing.collections, incoming.collections),
+    metadata: mergeRootMetadata(existing.metadata, incoming.metadata),
+  };
+}
+
+/**
+ * Full request -> response computation. Exposed for unit testing.
+ */
+export function computeMergeResponse(requestBytes: Uint8Array): Uint8Array {
+  try {
+    const request = decodeMergeRootStateRequest(requestBytes);
+
+    // Bootstrap fast-path: existing side never written -> take incoming.
+    if (request.existingCreatedAt === request.existingTs) {
+      return encodeMergeRootStateResponseOk(request.incoming);
+    }
+
+    const existing = parseRootDocument(request.existing);
+    const incoming = parseRootDocument(request.incoming);
+    const merged = mergeRootDocuments(existing, incoming);
+    return encodeMergeRootStateResponseOk(serializeRootDocument(merged));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return encodeMergeRootStateResponseErr(message);
+  }
+}
+
+// --- Host export ----------------------------------------------------------
+
+function readInput(): Uint8Array {
+  env.input(REGISTER_ID);
+  const len = Number(env.registerLen(REGISTER_ID));
+  if (!Number.isFinite(len) || len <= 0) {
+    return new Uint8Array(0);
+  }
+  const buffer = new Uint8Array(len);
+  env.readRegister(REGISTER_ID, buffer);
+  return buffer;
+}
+
+export function handleMergeRootState(): void {
+  try {
+    const requestBytes = readInput();
+    const response = computeMergeResponse(requestBytes);
+    env.valueReturnRaw(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    env.log(`[merge] __calimero_merge_root_state error=${message}`);
+    try {
+      env.valueReturnRaw(encodeMergeRootStateResponseErr(message));
+    } catch {
+      // Nothing more we can do if even the error response fails.
+    }
+  }
+}
+
+/**
+ * Invoked from the `__calimero_register_merge` hook. `@Mergeable` descriptors
+ * self-register at import time; this just reports how many are known.
+ */
+export function registerMergeTypes(): void {
+  env.log(`[merge] register_merge: ${mergeableTypeCount()} mergeable type(s) registered`);
+}
+
+(globalThis as any).__calimero_merge_root_state = handleMergeRootState;

--- a/packages/sdk/src/runtime/mergeable-registry.ts
+++ b/packages/sdk/src/runtime/mergeable-registry.ts
@@ -33,6 +33,13 @@ export function getMergeableDescriptor(type: string): MergeableDescriptor | unde
   return descriptors.get(type);
 }
 
+/**
+ * Number of `@Mergeable` types registered so far. Informational only.
+ */
+export function mergeableTypeCount(): number {
+  return descriptors.size;
+}
+
 export function cloneMergeableValue<T>(value: T): T {
   if (value === null || typeof value !== 'object') {
     return value;

--- a/packages/sdk/src/runtime/root.ts
+++ b/packages/sdk/src/runtime/root.ts
@@ -18,6 +18,90 @@ interface PersistedStateDocument {
 }
 
 const ROOT_METADATA = Symbol.for('__calimeroRootMetadata');
+const ROOT_FORMAT_VERSION = 1;
+
+/**
+ * Decoded root document, independent of any live state instance.
+ *
+ * Shared by the persistence path ({@link saveRootState}/{@link loadRootState})
+ * and the field-aware sync merge ({@link parseRootDocument} /
+ * {@link serializeRootDocument}).
+ */
+export interface RootDocument {
+  values: Record<string, unknown>;
+  collections: Record<string, CollectionSnapshot>;
+  metadata: { createdAt: number; updatedAt: number };
+}
+
+function stateTypeRefFromAbi(): { stateTypeRef: TypeRef; abi: ReturnType<typeof getAbiManifest> } {
+  const abi = getAbiManifest();
+  if (!abi) {
+    throw new Error(
+      'ABI manifest is required but not available for root document (de)serialization'
+    );
+  }
+  const stateRootType = getStateRootType(abi);
+  if (!stateRootType || stateRootType.kind !== 'record') {
+    throw new Error('Invalid or missing state_root type in ABI');
+  }
+  const stateTypeRef: TypeRef = { kind: 'reference', name: abi.state_root };
+  return { stateTypeRef, abi };
+}
+
+/**
+ * Pure decode of the persisted root-document wire format into its parts.
+ *
+ * Wire format: `[u8 version=1][writeBytes(abi state)][writeBytes(collections+metadata)]`
+ */
+export function parseRootDocument(source: Uint8Array): RootDocument {
+  const reader = new BorshReader(source);
+  const formatVersion = reader.readU8();
+  if (formatVersion !== ROOT_FORMAT_VERSION) {
+    throw new Error(
+      `Unsupported state format version: ${formatVersion} (expected ${ROOT_FORMAT_VERSION})`
+    );
+  }
+
+  const { stateTypeRef, abi } = stateTypeRefFromAbi();
+  const stateBytes = reader.readBytes();
+  const values = deserializeWithAbi(stateBytes, stateTypeRef, abi!) as Record<string, unknown>;
+
+  const collectionsAndMetadataBytes = reader.readBytes();
+  const collectionsAndMetadata =
+    collectionsAndMetadataBytes.length > 0
+      ? deserialize<any>(collectionsAndMetadataBytes)
+      : { collections: {}, metadata: null };
+
+  const now = Number(env.timeNow());
+  return {
+    values,
+    collections: collectionsAndMetadata.collections || {},
+    metadata: collectionsAndMetadata.metadata || { createdAt: now, updatedAt: now },
+  };
+}
+
+/**
+ * Pure encode of a {@link RootDocument} back into the persisted wire format.
+ *
+ * Does NOT touch the host (no `persist_root_state`); the merge callback returns
+ * these bytes to core, which persists them.
+ */
+export function serializeRootDocument(doc: RootDocument): Uint8Array {
+  const { stateTypeRef, abi } = stateTypeRefFromAbi();
+  const statePayload = serializeWithAbi(doc.values, stateTypeRef, abi!);
+
+  const writer = new BorshWriter();
+  writer.writeU8(ROOT_FORMAT_VERSION);
+  writer.writeBytes(statePayload);
+
+  const collectionsAndMetadata = serialize({
+    collections: doc.collections,
+    metadata: doc.metadata,
+  });
+  writer.writeBytes(collectionsAndMetadata);
+
+  return writer.toBytes();
+}
 
 export function saveRootState(state: any): Uint8Array {
   if (!state || typeof state !== 'object') {

--- a/packages/sdk/src/runtime/storage-wasm.ts
+++ b/packages/sdk/src/runtime/storage-wasm.ts
@@ -13,6 +13,13 @@ import {
   registerLen,
   readRegister,
   jsCrdtMapNew,
+  jsCrdtMapNewWithId,
+  jsCrdtVectorNewWithId,
+  jsCrdtSetNewWithId,
+  jsCrdtLwwNewWithId,
+  jsCrdtCounterNewWithId,
+  jsUserStorageNewWithId,
+  jsFrozenStorageNewWithId,
   jsCrdtMapGet,
   jsCrdtMapInsert,
   jsCrdtMapRemove,
@@ -100,6 +107,57 @@ export function mapNew(): Uint8Array {
     throw new Error(`[storage] mapNew returned invalid map id length (${id.length})`);
   }
   return id;
+}
+
+// --- Deterministic-id constructors ---------------------------------------
+//
+// These create a collection *at a caller-supplied 32-byte id* via the host
+// `*_new_with_id` functions. Used for concurrent-writer convergence so two
+// nodes address the same entity for the same logical state field.
+
+function newCollectionWithId(
+  id: Uint8Array,
+  call: (id: Uint8Array, register: bigint) => number,
+  operation: string
+): Uint8Array {
+  ensureCollectionId(id, `${operation}.id`);
+  const status = Number(call(id, REGISTER_ID));
+  if (status < 0) {
+    decodeError(operation);
+  }
+  const returnedId = readRegisterBytes();
+  if (returnedId.length !== COLLECTION_ID_LENGTH) {
+    throw new Error(`[storage] ${operation} returned invalid id length (${returnedId.length})`);
+  }
+  return returnedId;
+}
+
+export function mapNewWithId(id: Uint8Array): Uint8Array {
+  return newCollectionWithId(id, jsCrdtMapNewWithId, 'mapNewWithId');
+}
+
+export function vectorNewWithId(id: Uint8Array): Uint8Array {
+  return newCollectionWithId(id, jsCrdtVectorNewWithId, 'vectorNewWithId');
+}
+
+export function setNewWithId(id: Uint8Array): Uint8Array {
+  return newCollectionWithId(id, jsCrdtSetNewWithId, 'setNewWithId');
+}
+
+export function lwwNewWithId(id: Uint8Array): Uint8Array {
+  return newCollectionWithId(id, jsCrdtLwwNewWithId, 'lwwNewWithId');
+}
+
+export function counterNewWithId(id: Uint8Array): Uint8Array {
+  return newCollectionWithId(id, jsCrdtCounterNewWithId, 'counterNewWithId');
+}
+
+export function userStorageNewWithId(id: Uint8Array): Uint8Array {
+  return newCollectionWithId(id, jsUserStorageNewWithId, 'userStorageNewWithId');
+}
+
+export function frozenStorageNewWithId(id: Uint8Array): Uint8Array {
+  return newCollectionWithId(id, jsFrozenStorageNewWithId, 'frozenStorageNewWithId');
 }
 
 export function mapGet(mapId: Uint8Array, key: Uint8Array): Uint8Array | null {

--- a/packages/sdk/src/utils/deterministic-id.ts
+++ b/packages/sdk/src/utils/deterministic-id.ts
@@ -1,0 +1,71 @@
+/**
+ * Deterministic collection ID derivation.
+ *
+ * Concurrent-writer convergence requires that two nodes address the *same*
+ * CRDT entity for the same logical state field. Because a JS app root is
+ * opaque to core, the guest is responsible for choosing collection ids. As
+ * long as every node runs the same guest code, deriving an id purely from the
+ * field path yields the same 32-byte id everywhere, so `*_new_with_id` creates
+ * (or re-opens) the same entity on each node and core's CRDT merge unifies
+ * their contents on sync.
+ *
+ * NOTE: these ids only need to be *identical across nodes* for the same field;
+ * the guest supplies the id to the host `*_new_with_id` functions, so the
+ * derivation does not have to match core's internal id scheme byte-for-byte.
+ * The domain separators mirror `core/crates/storage` so the two schemes stay
+ * compatible if core ever needs to reproduce a guest-chosen id.
+ */
+
+import { sha256 } from './sha256';
+
+const encoder = new TextEncoder();
+
+const DOMAIN_SEPARATOR_COLLECTION = encoder.encode('__calimero_collection__');
+const DOMAIN_SEPARATOR_ENTRY = encoder.encode('__calimero_entry__');
+
+/**
+ * The root parent id (all-zero 32 bytes). Top-level `@State` collection fields
+ * are derived as children of the root.
+ */
+export const ROOT_ID: Uint8Array = new Uint8Array(32);
+
+function concat(...arrays: Uint8Array[]): Uint8Array {
+  const total = arrays.reduce((sum, arr) => sum + arr.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const arr of arrays) {
+    out.set(arr, offset);
+    offset += arr.length;
+  }
+  return out;
+}
+
+/**
+ * Compute the deterministic id for a collection field.
+ *
+ * Formula: SHA256(parentId? + "__calimero_collection__" + fieldName)
+ *
+ * @param parentId - Parent entity id (use {@link ROOT_ID} for top-level fields), or null
+ * @param fieldName - The logical field name
+ * @returns 32-byte deterministic id
+ */
+export function computeCollectionId(parentId: Uint8Array | null, fieldName: string): Uint8Array {
+  const fieldNameBytes = encoder.encode(fieldName);
+  const data = parentId
+    ? concat(parentId, DOMAIN_SEPARATOR_COLLECTION, fieldNameBytes)
+    : concat(DOMAIN_SEPARATOR_COLLECTION, fieldNameBytes);
+  return sha256(data);
+}
+
+/**
+ * Compute the deterministic id for a map/set entry.
+ *
+ * Formula: SHA256(parentId + "__calimero_entry__" + key)
+ *
+ * @param parentId - Parent collection id
+ * @param key - Serialized entry key bytes
+ * @returns 32-byte deterministic id
+ */
+export function computeEntryId(parentId: Uint8Array, key: Uint8Array): Uint8Array {
+  return sha256(concat(parentId, DOMAIN_SEPARATOR_ENTRY, key));
+}


### PR DESCRIPTION
## What

The JS SDK side of concurrent-writer convergence (#83). Pairs with core#3309 + core#3314 (merged) and **core#3315** (the JS-root-as-`ROOT_ENTRY_ID`-leaf fix).

## Changes

- **`__calimero_merge_root_state` export** + **`register_js_sdk_root_merge`** wiring: JS roots merge field-aware on sync via the HashComparison deferred path. Byte-verified against core's `MergeRootStateRequest`/`Response`.
- **Deterministic collection ids** via `*_new_with_id` (id derived from field path), so two nodes address the same entity per logical field.
- Host bindings (`bindings.ts`, `api.ts`, `builder.c`) + CLI export (`methods.ts`).
- **Persist-then-flush ordering fix** (`dispatcher.ts`): mutating methods now `StateManager.save()` **before** `flushDelta()`, matching the `@Init` path. The old order flushed the delta before persisting the root doc, so the root entity's storage action landed after the flush and was dropped from the broadcast delta → `root_hash=Some` with an empty artifact → the node rejected it as `StateInconsistency` (surfaced as an opaque node-side Runtime error on the joined node — the **#84/#85** failures).

## Validation (real 2-node networks, merod built from core#3309+#3314+#3315)

**3 of the 4 previously-gated concurrent-writer workflows now pass end-to-end** (`🎉 Workflow completed successfully!`):
- ✅ `test_user_storage`
- ✅ `test_frozen_storage`
- ✅ `private-data` (incl. `setPrivateNote` on the joined node — the #85 symptom)

`xcall` remains gated — it's a **separate** cross-context dispatch bug (`pong` never executes), tracked in **#84**, unrelated to convergence.

## Tests / build

`pnpm build` clean; `pnpm test` green (incl. `merge.test.ts`, `deterministic-id.test.ts`); example WASMs build and export `__calimero_merge_root_state` / import the new host fns (`wasm-objdump`-verified).

## Depends on

- **core#3315** merged + `merod:edge` rebuilt (the leaf fix; convergence only works with it on the node).
- Rebase onto **#77** (baseline) or master.

Once core#3315 is on the edge, re-enable `user-storage`/`frozen-storage`/`private-data` in CI (leave `xcall` gated behind #84).