### PR TITLE
debug(3333): SortedSet ordered-read divergence trace repro (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,21 @@ jobs:
                 --verbose; then
               FAILED_WORKFLOWS+=("$workflow")
             fi
+            # TRACE DIAGNOSTIC (core#3333): before tearing the containers down,
+            # dump the ordered-index / sync trace from every running node. Tiny,
+            # grepped output — only the SortedSet ordered-index and deferred-root-
+            # merge lines. Captured for ALL workflows but only the concurrent
+            # SortedSet one (nodes prefixed `crdt-conv-node`, log_level set in its
+            # YAML) emits sorted_index_dbg lines. Runs before stop/nuke so the
+            # containers still exist.
+            echo "===== [3333-trace] node logs for: $workflow ====="
+            for c in $(docker ps -a --format '{{.Names}}' | grep -E 'crdt-conv-node' || true); do
+              echo "----- [3333-trace] container: $c -----"
+              docker logs "$c" 2>&1 | grep -E \
+                'sorted_index_dbg|SortedIndexMeta|ensure_index|rebuild_index|APPLY_ADD|CHECK index|STAMP index|REBUILD index|write_pre_merged|deferred root merge|marker' \
+                || echo "  (no matching trace lines)"
+            done
+            echo "===== [3333-trace] end node logs ====="
             merobox stop --all || true
             merobox nuke -f || true
           done

--- a/examples/crdt-collections/workflows/crdt-collections-concurrent.yml
+++ b/examples/crdt-collections/workflows/crdt-collections-concurrent.yml
@@ -11,6 +11,13 @@ name: CRDT Collections Convergence (two nodes)
 
 force_pull_image: true
 
+# TRACE DIAGNOSTIC (core#3333): passed verbatim to each node container as
+# RUST_LOG. Surfaces the JS-path ordered-index instrumentation carried by the
+# instrumented merod:edge image (calimero_storage::sorted_index_dbg:
+# APPLY_ADD / CHECK / REBUILD / STAMP), plus the storage merge/apply layer and
+# the node sync (HashComparison / deferred-root-merge) path #3333 localizes to.
+log_level: "info,calimero_storage::sorted_index_dbg=debug,calimero_storage=debug,calimero_node::sync=debug"
+
 nodes:
   chain_id: testnet-1
   count: 2
@@ -162,18 +169,44 @@ steps:
     outputs:
       score_node_2: result.output
 
-  # NOTE: concurrent-writer convergence of SortedSet/SortedMap ORDERED reads
-  # (allTags/iter) is gated on calimero-network/core#3333: after concurrent
-  # writes the element set converges (contains/size agree on every node) but the
-  # node-local ordered index serves a stale subset on the peer. Point/membership
-  # ops and PNCounter converge, so this workflow asserts PNCounter convergence;
-  # the SortedSet ordered-read convergence assertion is re-enabled once #3333
-  # lands. Single-writer SortedSet/SortedMap is covered by crdt-collections-js.yml.
+  # --- SortedSet ORDERED-READ convergence (the core#3333 discriminator) ------
+  # After concurrent adds ("a" on node-1, "b" on node-2), membership converges
+  # (contains/size agree cross-node) but the node-local ordered index can serve
+  # a stale subset on the peer. `allTags()` is index-backed (toArray -> host
+  # SortedSet::iter -> ensure_index -> index_marker_current), so each call also
+  # emits a `CHECK index marker` line into the node log. If the ordered index is
+  # stale (marker stamped ahead of the child set) the returned array is a subset
+  # — NOT ["a","b"] — even though membership agreed. Re-enabled to REPRODUCE
+  # #3333 and capture the decisive node-2 trace on the instrumented edge image.
+  - name: Read All Tags On Node 1
+    type: call
+    node: crdt-conv-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: allTags
+    outputs:
+      tags_node_1: result.output
+
+  - name: Read All Tags On Node 2
+    type: call
+    node: crdt-conv-node-2
+    context_id: '{{context_id}}'
+    executor_public_key: '{{node_2_member_public_key}}'
+    method: allTags
+    outputs:
+      tags_node_2: result.output
+
   - name: Assert Convergence
     type: json_assert
     statements:
       - 'equal({{score_node_1}}, 4)'
       - 'equal({{score_node_2}}, 4)'
+      # core#3333 discriminator: ordered iteration must converge to the full set
+      # on BOTH nodes. Expected to FAIL on the stale-index peer until #3333 is
+      # fixed — the failure is the reproduction; node-2's grepped log is the
+      # decisive trace.
+      - 'equal({{tags_node_1}}, ["a", "b"])'
+      - 'equal({{tags_node_2}}, ["a", "b"])'
 
 stop_all_nodes: false
 restart: true


### PR DESCRIPTION
Diagnostic-only draft for calimero-network/core#3333.

Re-enables the concurrent-writer SortedSet ordered-read (`allTags` == `["a","b"]`) convergence assertion in `crdt-collections-concurrent.yml` (previously gated behind #3333) so it reproduces the cross-node divergence against the instrumented `merod:edge` image, sets the node `log_level` to surface `calimero_storage::sorted_index_dbg` (APPLY_ADD / CHECK / REBUILD / STAMP) + storage merge + node sync, and dumps the grepped node trace from each `crdt-conv-node` container in CI before teardown.

The merobox job is EXPECTED to fail (the divergence is the reproduction). Purpose is to pull node-2's decisive ordered-index trace from the job log to pin the JS-path mechanism. Not for merge.