### PR TITLE
feat(sdk): add SharedStorage CRDT collection (Phase 2b)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -70,7 +70,7 @@ export default defineConfig({
         },
         {
           label: 'Understand',
-          items: ['understand/architecture'],
+          items: ['understand/architecture', 'understand/rust-sdk-comparison'],
         },
         {
           label: 'Reference',

--- a/docs/src/content/docs/guides/collections.mdx
+++ b/docs/src/content/docs/guides/collections.mdx
@@ -1,6 +1,6 @@
 ---
 title: CRDT Collections
-description: The conflict-free replicated data types the JS SDK provides — UnorderedMap, UnorderedSet, Vector, Counter, LwwRegister, plus UserStorage and FrozenStorage — how they sync, how nested collections work, and best practices per type.
+description: The conflict-free replicated data types the JS SDK provides — maps, sets, vectors, counters and registers, their sorted and attributed variants, an RGA text type, plus per-user, immutable, and group-writable storage — how they sync, how nested collections work, and best practices per type.
 sidebar:
   order: 1
 ---
@@ -109,6 +109,29 @@ const mine = counter.getExecutorCount();
   takes an optional hex-encoded executor id string and returns a `number`.
 </Aside>
 
+## PNCounter
+
+Positive-negative counter (PN-Counter) — like `Counter`, but it also supports
+`decrement`. Each node keeps a per-node increment and decrement tally; the value
+is the signed sum, so concurrent up/down changes from different nodes never
+conflict or lose updates.
+
+```typescript
+const votes = new PNCounter();
+
+votes.increment(); // +1
+votes.incrementBy(5); // +5
+votes.decrement(); // −1
+votes.decrementBy(2); // −2 (accepts number | bigint)
+const net = votes.value(); // bigint — can be negative
+```
+
+<Aside type="note">
+  Use `PNCounter` when a value goes both up and down (score, balance, stock).
+  Use `Counter` when it only ever grows — a grow-only counter is cheaper and
+  cannot be driven negative.
+</Aside>
+
 ## LwwRegister&lt;T&gt;
 
 Last-write-wins register for a single value.
@@ -122,10 +145,111 @@ const ts = register.timestamp();    // number | null — when it was set
 register.clear();                   // void
 ```
 
+## SortedMap&lt;K, V&gt;
+
+Same last-write-wins semantics and API as `UnorderedMap`, but iteration is in
+**sorted key order** instead of arbitrary order. Ordering is maintained by a
+node-local index, so `entries()`/`keys()`/`values()` are deterministic.
+
+```typescript
+const scores = new SortedMap<string, number>();
+
+scores.set('charlie', 3);
+scores.set('alice', 1);
+scores.set('bob', 2);
+
+const ordered = scores.keys(); // ['alice', 'bob', 'charlie'] — always sorted
+scores.get('bob'); // 2 | null
+scores.has('bob'); // boolean
+scores.remove('bob'); // void
+```
+
+## SortedSet&lt;T&gt;
+
+Sorted counterpart to `UnorderedSet` — union (add-wins) membership, but
+`toArray()` returns values in sorted order.
+
+```typescript
+const tags = new SortedSet<string>();
+
+tags.add('c'); // true on first insert, false if already present
+tags.add('a');
+tags.add('b');
+
+tags.toArray(); // ['a', 'b', 'c'] — always sorted
+tags.has('a'); // boolean
+tags.delete('a'); // boolean
+tags.size(); // number
+```
+
+## Rga&lt;T&gt;
+
+Replicated Growable Array — a sequence CRDT for **collaborative text**.
+Concurrent inserts and deletes from different nodes interleave deterministically
+by position, so two editors typing at once converge without losing characters.
+
+```typescript
+const doc = new Rga();
+
+doc.insert(0, 'Hello'); // insert text at an index
+doc.insert(5, ' world'); // → 'Hello world'
+doc.delete(0); // remove one element at an index
+const text = doc.getText(); // current string
+const length = doc.len(); // number of elements
+```
+
+<Aside type="note">
+  Prefer `Rga` over `LwwRegister<string>` when multiple writers edit the same
+  text concurrently — `LwwRegister` keeps only the last write, discarding the
+  other editor's changes, whereas `Rga` merges them character by character.
+</Aside>
+
+## Attributed collections
+
+Attributed (authored) collections record the **owner** of each entry — the
+executor that created it — and enforce that only that owner may update or remove
+it. Ownership travels with the entry and is verified on every node, so one
+member cannot overwrite another member's data.
+
+### AuthoredMap&lt;K, V&gt;
+
+Like `UnorderedMap`, but each key is owned by its first inserter.
+
+```typescript
+const claims = new AuthoredMap<string, string>();
+
+claims.insert('seat-1', 'alice'); // owned by the current executor
+claims.update('seat-1', 'alice-2'); // ok only if you own 'seat-1' (throws otherwise)
+claims.set('seat-1', 'alice-2'); // insert-or-update, owner-checked on update
+claims.get('seat-1'); // V | null
+claims.ownerOf('seat-1'); // Uint8Array (owner public key) | null
+claims.ownedByMe('seat-1'); // boolean
+claims.remove('seat-1'); // owner-checked
+```
+
+### AuthoredVector&lt;T&gt;
+
+Like `Vector`, but each slot is owned by whoever pushed it; updates and removals
+are owner-gated and removal is a **tombstone** (the slot index stays stable).
+
+```typescript
+const log = new AuthoredVector<string>();
+
+const index = log.push('entry'); // returns the slot index; owned by the caller
+log.update(index, 'edited'); // owner-only
+log.tombstone(index); // owner-only soft-delete
+log.get(index); // T | null (null once tombstoned)
+log.ownerOf(index); // Uint8Array | null
+log.ownedByMe(index); // boolean
+log.len(); // number of slots (including tombstones)
+log.toArray(); // live values
+```
+
 ## Conflict resolution
 
-For last-write-wins types (`UnorderedMap`, `UnorderedSet`, `LwwRegister`) a
-concurrent write to the same key is resolved by timestamp — the later write wins:
+For last-write-wins types (`UnorderedMap`, `UnorderedSet`, `LwwRegister`,
+`SortedMap`, `SortedSet`, and `SharedStorage`'s value) a concurrent write to the
+same key is resolved by timestamp — the later write wins:
 
 ```
 Node A: map.set('key', 'A') at t=1000
@@ -133,8 +257,13 @@ Node B: map.set('key', 'B') at t=1001
 Result: key = 'B' (higher timestamp)
 ```
 
-`Counter` is different: increments from different nodes are additive and never
-lost.
+The other types resolve differently and never lose concurrent updates:
+
+- `Counter` / `PNCounter` — per-node tallies are summed (additive).
+- `Rga` — concurrent inserts/deletes interleave by position (union of edits).
+- `AuthoredMap` / `AuthoredVector` — each entry is owner-gated, so only its owner
+  can change it; there is no cross-writer conflict on a single entry.
+- `FrozenStorage` — first write wins; entries are immutable.
 
 ## Nested collections
 
@@ -251,11 +380,53 @@ Values are wrapped in `FrozenValue<T>` (`new FrozenValue(value)`, `.value`),
 whose `merge` is a no-op so frozen entries never change. Use it for audit logs,
 document versioning, certificates, and content-addressable sharing.
 
+### SharedStorage&lt;V&gt;
+
+A single value that any member of a **rotatable writer set** may overwrite.
+Writes from different writers converge last-write-wins; the writer set is managed
+at runtime and enforced by the host — a non-writer's `set`/`rotateWriters` is
+rejected. Writers are 32-byte public keys (raw or hex).
+
+```typescript
+import { SharedStorage } from '@calimero-network/calimero-sdk-js/collections';
+import { executorId } from '@calimero-network/calimero-sdk-js/env';
+
+// The creator is the sole initial writer.
+const config = new SharedStorage<string>({ writers: [executorId()] });
+
+config.set('hello'); // ok — caller is a writer (throws for a non-writer)
+config.get(); // 'hello' | null
+config.writers(); // Uint8Array[] — current writer set
+config.writableByMe(); // boolean
+config.isFrozen(); // boolean — a frozen cell is immutable
+
+// Grant another member write access (writer-gated):
+config.rotateWriters([...config.writers(), otherKey]);
+```
+
+<Aside type="note">
+  The writer set must be non-empty — a cell with no writers can never be written
+  or recovered, so the SDK rejects it. Use `SharedStorage.fromId(id)` to reopen
+  an existing cell without touching its value or writers; passing `{ writers, id }`
+  **creates** a cell at that id (this is how deterministic `@State` fields get a
+  stable, cross-node id). Optional per-writer capabilities and
+  `SharedStorage<Collection>` nesting are not yet exposed in the JS SDK.
+</Aside>
+
+Use it for shared configuration, group-editable records, or any value a defined
+set of members may change while everyone else reads. It differs from
+`AuthoredMap`/`UserStorage` (which gate *per entry* by the entry's own owner):
+`SharedStorage` gates the *whole cell* by a single, rotatable writer set.
+
 ## Best practices
 
-- **Pick the right type**: `UnorderedMap` for key/value data, `Vector` for
-  ordered lists, `Counter` for totals, `LwwRegister` for single values,
-  `UserStorage` for per-user ownership, `FrozenStorage` for immutable records.
+- **Pick the right type**: `UnorderedMap`/`SortedMap` for key/value data
+  (sorted when you need ordered iteration), `Vector` for ordered lists,
+  `Counter` for grow-only totals and `PNCounter` when it also decreases,
+  `LwwRegister` for a single value, `Rga` for collaboratively-edited text,
+  `AuthoredMap`/`AuthoredVector` when each entry has a single owner,
+  `UserStorage` for per-user ownership, `FrozenStorage` for immutable records,
+  and `SharedStorage` for one value a rotatable set of writers may change.
 - **Mutate the handle, don't replace it.** Fetch the existing entry
   (`const v = map.get(key) ?? new …`) and mutate it. Assigning a brand-new CRDT
   instance replaces the stored ID and falls back to whole-value last-write-wins.

--- a/docs/src/content/docs/understand/rust-sdk-comparison.mdx
+++ b/docs/src/content/docs/understand/rust-sdk-comparison.mdx
@@ -1,0 +1,99 @@
+---
+title: JS SDK vs. the Rust SDK
+description: How the JavaScript Service SDK relates to Calimero's native Rust SDK — the same programming model, CRDTs, ABI, and convergence, and where the two differ in language, tooling, performance, and feature coverage.
+sidebar:
+  order: 2
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Calimero apps can be written in **Rust** (the native `calimero-sdk`, part of
+[calimero-network/core](https://github.com/calimero-network/core)) or in
+**TypeScript/JavaScript** (this SDK). Both compile to a single WASM module that
+the node runs the same way. This page maps the two so you can move between them.
+
+The short version: the **programming model is the same** — the same app
+structure, the same CRDT collections, the same events, the same ABI, and the
+same convergence guarantees. The differences are in **language, tooling, and a
+few advanced features** that the Rust SDK, as the reference implementation, gets
+first.
+
+## What's the same
+
+Both SDKs target one runtime, so most of what you learn transfers directly:
+
+- **Same platform.** Your code compiles to WASM and runs inside the node's
+  runtime, reaching the node only through the Calimero host functions. The
+  storage layer, CRDT engine, causal DAG, P2P sync, and access control are
+  identical — they live in the node, not the SDK.
+- **Same app shape.** A state type, a logic block with methods, an initializer,
+  events, and read-only views — expressed with decorators in JS and attribute
+  macros in Rust (table below).
+- **Same CRDT collections.** `UnorderedMap`, `UnorderedSet`, `Vector`,
+  `Counter`, `PNCounter`, `LwwRegister`, `Rga`, `SortedMap`, `SortedSet`,
+  `AuthoredMap`, `AuthoredVector`, `UserStorage`, `FrozenStorage`, and
+  `SharedStorage` exist in both, with the same names and the same convergence
+  semantics. See [CRDT Collections](/guides/collections/).
+- **Same convergence.** Concurrent writes converge by the same rules on both —
+  last-write-wins by timestamp, additive counters, RGA interleaving, owner-gated
+  attributed entries — because the merge happens in the node, not the SDK.
+- **Same ABI, so clients don't care.** Both emit the mandatory `calimero_abi_v1`
+  manifest, and values use Calimero's Borsh encoding. A generated client works
+  the same against a JS or a Rust service, and a state written under one is
+  readable by the other given the same schema — which is what makes
+  [migrating a Rust app to JS](/guides/migration/) (or back) possible.
+
+## Side-by-side
+
+| Concept              | Rust SDK (`calimero-sdk`)                     | JS SDK (`@calimero-network/calimero-sdk-js`)         |
+| -------------------- | --------------------------------------------- | ---------------------------------------------------- |
+| Language / target    | Rust → native `wasm32`                        | TypeScript/JS → QuickJS compiled to WASM             |
+| Build                | `cargo mero build`                            | `calimero-sdk build` (Rollup → QuickJS → WASM)       |
+| State type           | `#[app::state]`                               | `@State`                                             |
+| Logic / methods      | `#[app::logic] impl`                          | `@Logic` class                                       |
+| Initializer          | `#[app::init]`                                | `@Init`                                              |
+| Events               | `#[app::event]` + `app::emit!`                | `@Event` + `emit()`                                  |
+| Read-only methods    | `&self` methods                               | `@View()`                                            |
+| Method result        | `app::Result<T>`                              | return a value, or `throw`                           |
+| Serialization        | `borsh` derive                                | ABI-driven `serialize`/`deserialize` (Borsh-compatible) |
+| Collection ids       | assigned via the state macro                  | `new Collection()` + runtime deterministic-id assignment |
+| Custom conflict rules | custom CRDT merge via a WASM callback         | [`@Mergeable` structs](/guides/mergeable-js/)        |
+
+## What differs
+
+- **Language and tooling.** Rust gives you a compiler-checked type system,
+  `cargo`, and crates; JS/TS gives you a faster edit loop and the npm ecosystem.
+  App structure is expressed with **attribute macros** in Rust and
+  **decorators** in JS, but they mean the same thing.
+- **Performance and size.** A Rust service compiles to compact native WASM. A JS
+  service ships the QuickJS interpreter inside its WASM and interprets your
+  bytecode, so it is larger and slower per call. For most collaborative apps this
+  is not the bottleneck (sync and storage dominate); for hot, compute-heavy paths
+  Rust is the better fit.
+- **How root state converges (internals).** Both converge to the same result,
+  but the mechanism differs: a Rust structured state merges in-guest, while a JS
+  state's root merge is driven host-side (`__calimero_merge_root_state`). You do
+  not write this code in either SDK — see the
+  [architecture](/understand/architecture/) for the JS data flow.
+- **Feature coverage.** The Rust SDK is the reference implementation, so a few
+  advanced capabilities land there first. For example, `SharedStorage`'s
+  per-writer capabilities and `SharedStorage<Collection>` nesting are not yet
+  exposed in JS. The core CRDT set and everyday app model are at parity.
+
+<Aside type="tip">
+  Choose **Rust** for maximum performance, the strongest type guarantees, or a
+  feature only it exposes yet. Choose **JS/TS** for a fast iteration loop, web
+  and Node developers, or sharing types with a TypeScript frontend. Because both
+  produce ABI-compatible services, you can also start in JS and rewrite the hot
+  parts (or the whole app) in Rust later — see
+  [Migrating from the Rust SDK](/guides/migration/).
+</Aside>
+
+## See also
+
+- [Architecture](/understand/architecture/) — the QuickJS ↔ host runtime and
+  build pipeline in detail.
+- [CRDT Collections](/guides/collections/) — every collection type and its
+  convergence behavior.
+- [Migrating from the Rust SDK](/guides/migration/) — moving an app between the
+  two.

--- a/examples/shared-storage/README.md
+++ b/examples/shared-storage/README.md
@@ -1,0 +1,45 @@
+# SharedStorage Example
+
+Demonstrates `SharedStorage<V>` — a **group-writable single value with a
+rotatable writer set** (Phase 2b of the JS SDK CRDT-type expansion).
+
+A `SharedStorage` cell holds one value that any member of its *writer set* may
+overwrite. Writes from different writers converge last-write-wins, the writer set
+is managed at runtime, and the host rejects a non-writer's `set`/`rotateWriters`.
+
+This app (`TeamConfig`) models a shared team configuration string:
+
+- the context creator becomes the sole initial writer;
+- any writer can `setConfig(value)`;
+- a writer can `addWriter(publicKeyHex)` to grant another member write access.
+
+## Methods
+
+| Method | Kind | Description |
+| --- | --- | --- |
+| `setConfig(value)` | call | Overwrite the shared value (writer-gated). |
+| `getConfig()` | view | Current value, or `null` before the first write. |
+| `configWriters()` | view | Current writer set as hex public keys. |
+| `canWrite()` | view | Whether the caller may write. |
+| `isConfigFrozen()` | view | Whether the cell is frozen (immutable). |
+| `addWriter(publicKeyHex)` | call | Add a writer (writer-gated). |
+
+## Build
+
+```bash
+pnpm --filter shared-storage-example build:manual
+```
+
+## Test (merobox)
+
+```bash
+merobox bootstrap run examples/shared-storage/workflows/shared-storage-js.yml
+```
+
+> **Gated on core#3340.** The `js_crdt_shared_*` host functions ship in
+> calimero-network/core#3340; the workflow runs once that merges and the
+> `merod:edge` image is rebuilt.
+>
+> A concurrent multi-writer convergence workflow is deferred: adding a second
+> node as a writer needs its public key decoded in-guest, which the SDK does not
+> yet expose.

--- a/examples/shared-storage/README.md
+++ b/examples/shared-storage/README.md
@@ -11,18 +11,19 @@ This app (`TeamConfig`) models a shared team configuration string:
 
 - the context creator becomes the sole initial writer;
 - any writer can `setConfig(value)`;
-- a writer can `addWriter(publicKeyHex)` to grant another member write access.
+- a writer can `addWriter`/`addWriterBase58` to grant another member write access.
 
 ## Methods
 
-| Method                    | Kind | Description                                      |
-| ------------------------- | ---- | ------------------------------------------------ |
-| `setConfig(value)`        | call | Overwrite the shared value (writer-gated).       |
-| `getConfig()`             | view | Current value, or `null` before the first write. |
-| `configWriters()`         | view | Current writer set as hex public keys.           |
-| `canWrite()`              | view | Whether the caller may write.                    |
-| `isConfigFrozen()`        | view | Whether the cell is frozen (immutable).          |
-| `addWriter(publicKeyHex)` | call | Add a writer (writer-gated).                     |
+| Method                             | Kind | Description                                                              |
+| ---------------------------------- | ---- | ------------------------------------------------------------------------ |
+| `setConfig(value)`                 | call | Overwrite the shared value (writer-gated).                               |
+| `getConfig()`                      | view | Current value, or `null` before the first write.                         |
+| `configWriters()`                  | view | Current writer set as hex public keys.                                   |
+| `canWrite()`                       | view | Whether the caller may write.                                            |
+| `isConfigFrozen()`                 | view | Whether the cell is frozen (immutable).                                  |
+| `addWriter(publicKeyHex)`          | call | Add a writer by hex key (writer-gated).                                  |
+| `addWriterBase58(publicKeyBase58)` | call | Add a writer by base58 key — the form tooling/workflows surface keys in. |
 
 ## Build
 
@@ -33,13 +34,14 @@ pnpm --filter shared-storage-example build:manual
 ## Test (merobox)
 
 ```bash
+# Single-node: creator sets/reads/overwrites the shared value.
 merobox bootstrap run examples/shared-storage/workflows/shared-storage-js.yml
+
+# Two-node: creator rotates a second node into the writer set, both write, and
+# every replica converges on the shared value (last-write-wins).
+merobox bootstrap run examples/shared-storage/workflows/shared-storage-concurrent.yml
 ```
 
-> **Gated on core#3340.** The `js_crdt_shared_*` host functions ship in
-> calimero-network/core#3340; the workflow runs once that merges and the
-> `merod:edge` image is rebuilt.
->
-> A concurrent multi-writer convergence workflow is deferred: adding a second
-> node as a writer needs its public key decoded in-guest, which the SDK does not
-> yet expose.
+Both require the `js_crdt_shared_*` host functions (calimero-network/core#3340)
+in the `merod:edge` image. The concurrent workflow decodes the second node's
+base58 member key in-guest via `env.base58ToBytes` before rotating it in.

--- a/examples/shared-storage/README.md
+++ b/examples/shared-storage/README.md
@@ -3,7 +3,7 @@
 Demonstrates `SharedStorage<V>` — a **group-writable single value with a
 rotatable writer set** (Phase 2b of the JS SDK CRDT-type expansion).
 
-A `SharedStorage` cell holds one value that any member of its *writer set* may
+A `SharedStorage` cell holds one value that any member of its _writer set_ may
 overwrite. Writes from different writers converge last-write-wins, the writer set
 is managed at runtime, and the host rejects a non-writer's `set`/`rotateWriters`.
 
@@ -15,14 +15,14 @@ This app (`TeamConfig`) models a shared team configuration string:
 
 ## Methods
 
-| Method | Kind | Description |
-| --- | --- | --- |
-| `setConfig(value)` | call | Overwrite the shared value (writer-gated). |
-| `getConfig()` | view | Current value, or `null` before the first write. |
-| `configWriters()` | view | Current writer set as hex public keys. |
-| `canWrite()` | view | Whether the caller may write. |
-| `isConfigFrozen()` | view | Whether the cell is frozen (immutable). |
-| `addWriter(publicKeyHex)` | call | Add a writer (writer-gated). |
+| Method                    | Kind | Description                                      |
+| ------------------------- | ---- | ------------------------------------------------ |
+| `setConfig(value)`        | call | Overwrite the shared value (writer-gated).       |
+| `getConfig()`             | view | Current value, or `null` before the first write. |
+| `configWriters()`         | view | Current writer set as hex public keys.           |
+| `canWrite()`              | view | Whether the caller may write.                    |
+| `isConfigFrozen()`        | view | Whether the cell is frozen (immutable).          |
+| `addWriter(publicKeyHex)` | call | Add a writer (writer-gated).                     |
 
 ## Build
 

--- a/examples/shared-storage/package.json
+++ b/examples/shared-storage/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "shared-storage-example",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Phase 2b SharedStorage demo (group-writable value with a rotatable writer set)",
+  "scripts": {
+    "build:manual": "calimero-sdk build src/index.ts -o build/service.wasm",
+    "clean": "rm -rf build"
+  },
+  "dependencies": {
+    "@calimero-network/calimero-sdk-js": "workspace:*"
+  },
+  "devDependencies": {
+    "@calimero-network/calimero-cli-js": "workspace:*",
+    "typescript": "^5.3.3"
+  }
+}

--- a/examples/shared-storage/src/index.ts
+++ b/examples/shared-storage/src/index.ts
@@ -97,7 +97,18 @@ export class TeamConfigLogic extends TeamConfig {
    */
   addWriter(publicKeyHex: string): void {
     env.log(`[shared-storage] addWriter(${publicKeyHex.slice(0, 16)}…)`);
+    const target = publicKeyHex.toLowerCase();
     const current = this.config.writers();
+    // Skip if already a writer — `rotateWriters` replaces the whole set, so a
+    // blind append would duplicate the key. Note this read-modify-write is not
+    // atomic across concurrent writers: `rotateWriters` is last-write-wins on
+    // the whole set, so two concurrent `addWriter` calls can drop one addition.
+    // A single admin performing rotations avoids that; a production app would
+    // serialise writer-set changes through one identity.
+    if (current.some(w => toHex(w) === target)) {
+      env.log('[shared-storage] addWriter: already a writer, skipping');
+      return;
+    }
     this.config.rotateWriters([...current, publicKeyHex]);
     emit(new WriterAdded(publicKeyHex));
   }

--- a/examples/shared-storage/src/index.ts
+++ b/examples/shared-storage/src/index.ts
@@ -112,4 +112,14 @@ export class TeamConfigLogic extends TeamConfig {
     this.config.rotateWriters([...current, publicKeyHex]);
     emit(new WriterAdded(publicKeyHex));
   }
+
+  /**
+   * Add a writer given a base58-encoded public key — the form node tooling and
+   * workflows surface member keys in. Decodes to raw bytes and delegates to the
+   * same writer-gated rotation as {@link addWriter}.
+   */
+  addWriterBase58(publicKeyBase58: string): void {
+    const bytes = env.base58ToBytes(publicKeyBase58);
+    this.addWriter(toHex(bytes));
+  }
 }

--- a/examples/shared-storage/src/index.ts
+++ b/examples/shared-storage/src/index.ts
@@ -1,0 +1,104 @@
+/**
+ * SharedStorage Example — a group-writable config value with a rotatable
+ * writer set (Phase 2b CRDT-type expansion).
+ *
+ * `SharedStorage<V>` holds a single value that any member of its *writer set*
+ * may overwrite; writes from different writers converge last-write-wins. The
+ * writer set is managed at runtime and enforced by the host — a non-writer's
+ * `set`/`rotateWriters` is rejected.
+ *
+ * This app models a shared team configuration string:
+ *   - the context creator becomes the sole initial writer,
+ *   - any writer can `setConfig`,
+ *   - a writer can add another member via `addWriter` (hex-encoded key), after
+ *     which that member may write too.
+ */
+
+import { State, Logic, Init, Event, View, emit } from '@calimero-network/calimero-sdk-js';
+import { SharedStorage } from '@calimero-network/calimero-sdk-js/collections';
+import * as env from '@calimero-network/calimero-sdk-js/env';
+
+@Event
+export class ConfigUpdated {
+  constructor(
+    public value: string,
+    public by: string
+  ) {}
+}
+
+@Event
+export class WriterAdded {
+  constructor(public writer: string) {}
+}
+
+function toHex(bytes: Uint8Array): string {
+  let out = '';
+  for (const b of bytes) {
+    out += b.toString(16).padStart(2, '0');
+  }
+  return out;
+}
+
+@State
+export class TeamConfig {
+  // A single shared config string. The initial writer set is the context
+  // creator (assigned here, where the executor identity is available). On fresh
+  // state the cell is re-opened at a deterministic id so every replica addresses
+  // the same entity; on load it is rehydrated from the persisted snapshot.
+  config: SharedStorage<string>;
+
+  constructor() {
+    this.config = new SharedStorage<string>({ writers: [env.executorId()] });
+  }
+}
+
+@Logic(TeamConfig)
+export class TeamConfigLogic extends TeamConfig {
+  @Init
+  static init(): TeamConfig {
+    env.log('[shared-storage] Initializing TeamConfig');
+    return new TeamConfig();
+  }
+
+  /** Overwrite the shared config value. Writer-gated. */
+  setConfig(value: string): void {
+    env.log(`[shared-storage] setConfig("${value}")`);
+    this.config.set(value);
+    emit(new ConfigUpdated(value, env.executorIdHex()));
+  }
+
+  /** Read the current config value, or null before the first write. */
+  @View()
+  getConfig(): string | null {
+    return this.config.get();
+  }
+
+  /** The current writer set, as hex-encoded 32-byte public keys. */
+  @View()
+  configWriters(): string[] {
+    return this.config.writers().map(toHex);
+  }
+
+  /** Whether the calling executor may write to the config. */
+  @View()
+  canWrite(): boolean {
+    return this.config.writableByMe();
+  }
+
+  /** Whether the config cell is frozen (immutable). */
+  @View()
+  isConfigFrozen(): boolean {
+    return this.config.isFrozen();
+  }
+
+  /**
+   * Add a writer (hex-encoded 32-byte public key) to the config's writer set.
+   * Writer-gated: only a current writer may rotate the set.
+   */
+  addWriter(publicKeyHex: string): void {
+    env.log(`[shared-storage] addWriter(${publicKeyHex.slice(0, 16)}…)`);
+    const current = this.config.writers();
+    this.config.rotateWriters([...current, publicKeyHex]);
+    emit(new WriterAdded(publicKeyHex));
+  }
+}

--- a/examples/shared-storage/tsconfig.json
+++ b/examples/shared-storage/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./build",
+    "rootDir": "./src",
+    "moduleResolution": "bundler",
+    "composite": false
+  },
+  "include": ["src/**/*"]
+}

--- a/examples/shared-storage/workflows/shared-storage-concurrent.yml
+++ b/examples/shared-storage/workflows/shared-storage-concurrent.yml
@@ -1,0 +1,162 @@
+description: SharedStorage concurrent multi-writer convergence (JavaScript SDK)
+name: SharedStorage convergence (two nodes)
+
+# Two-node convergence test for SharedStorage as a deterministic @State field:
+#   1. node 1 creates the context (sole initial writer),
+#   2. node 2 joins and node 1 rotates it into the writer set,
+#   3. both writers set a different value, and after sync every replica must
+#      converge to the same value (last-write-wins on the shared cell).
+#
+# Exercises the pieces the single-node workflow can't: writer-set rotation
+# syncing to a second node, and cross-node convergence of the SharedStorage
+# value addressed by its deterministic id. Requires calimero-network/core#3340
+# in merod:edge.
+
+force_pull_image: true
+
+nodes:
+  chain_id: testnet-1
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: shared-conv-node
+
+steps:
+  - name: Install SharedStorage Application
+    type: install_application
+    node: shared-conv-node-1
+    path: 'examples/shared-storage/build/service.wasm'
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create Namespace
+    type: create_namespace
+    node: shared-conv-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create Context
+    type: create_context
+    node: shared-conv-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    params: '{}'
+    outputs:
+      context_id: contextId
+      member_public_key: memberPublicKey
+
+  - name: Invite Node 2 To Namespace
+    type: create_namespace_invitation
+    node: shared-conv-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      node_2_invitation: invitation
+
+  - name: Wait For Namespace Governance To Gossip
+    type: wait
+    seconds: 5
+
+  - name: Node 2 Join Namespace
+    type: join_namespace
+    node: shared-conv-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{node_2_invitation}}'
+
+  - name: Node 2 Join Context
+    type: join_context
+    node: shared-conv-node-2
+    context_id: '{{context_id}}'
+    outputs:
+      node_2_member_public_key: memberPublicKey
+
+  - name: Wait After Node 2 Join
+    type: wait
+    seconds: 2
+
+  # --- Node 1 rotates node 2 into the writer set -------------------------
+  - name: Node 1 Adds Node 2 As Writer
+    type: call
+    node: shared-conv-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: addWriterBase58
+    args:
+      publicKeyBase58: '{{node_2_member_public_key}}'
+
+  - name: Wait For Writer Rotation To Sync
+    type: wait_for_sync
+    context_id: '{{context_id}}'
+    nodes:
+      - shared-conv-node-1
+      - shared-conv-node-2
+    timeout: 60
+    check_interval: 2
+
+  - name: Node 2 Is Now A Writer
+    type: call
+    node: shared-conv-node-2
+    context_id: '{{context_id}}'
+    executor_public_key: '{{node_2_member_public_key}}'
+    method: canWrite
+    outputs:
+      node_2_can_write: result.output
+
+  # --- Both writers set a different value --------------------------------
+  - name: Node 1 Sets Config
+    type: call
+    node: shared-conv-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: setConfig
+    args:
+      value: from-node-1
+
+  - name: Node 2 Sets Config
+    type: call
+    node: shared-conv-node-2
+    context_id: '{{context_id}}'
+    executor_public_key: '{{node_2_member_public_key}}'
+    method: setConfig
+    args:
+      value: from-node-2
+
+  - name: Wait For Convergence
+    type: wait_for_sync
+    context_id: '{{context_id}}'
+    nodes:
+      - shared-conv-node-1
+      - shared-conv-node-2
+    timeout: 60
+    check_interval: 2
+
+  # --- Assert both replicas converged ------------------------------------
+  - name: Read Config On Node 1
+    type: call
+    node: shared-conv-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: getConfig
+    outputs:
+      config_node_1: result.output
+
+  - name: Read Config On Node 2
+    type: call
+    node: shared-conv-node-2
+    context_id: '{{context_id}}'
+    executor_public_key: '{{node_2_member_public_key}}'
+    method: getConfig
+    outputs:
+      config_node_2: result.output
+
+  - name: Assert Convergence
+    type: json_assert
+    statements:
+      # node 2 was rotated into the writer set.
+      - 'equal({{node_2_can_write}}, true)'
+      # both replicas converged to the same SharedStorage value (LWW).
+      - 'equal({{config_node_1}}, {{config_node_2}})'
+
+stop_all_nodes: false
+restart: true
+wait_timeout: 180

--- a/examples/shared-storage/workflows/shared-storage-js.yml
+++ b/examples/shared-storage/workflows/shared-storage-js.yml
@@ -5,11 +5,9 @@ name: SharedStorage (single node)
 # is the sole writer and can set/read the shared config value, LWW-overwrite it,
 # and observe writer membership.
 #
-# Requires calimero-network/core#3340 (the js_crdt_shared_* host functions) in
-# the merod:edge image; runnable once #3340 merges and the image is rebuilt.
-# A concurrent multi-writer convergence workflow is deferred: adding a second
-# node as a writer needs its public key decoded in-guest, which the SDK does not
-# yet expose.
+# Requires the js_crdt_shared_* host functions (calimero-network/core#3340) in
+# the merod:edge image. For cross-node convergence with two writers, see
+# shared-storage-concurrent.yml in this directory.
 
 force_pull_image: true
 

--- a/examples/shared-storage/workflows/shared-storage-js.yml
+++ b/examples/shared-storage/workflows/shared-storage-js.yml
@@ -1,0 +1,124 @@
+description: SharedStorage single-writer flow (JavaScript SDK)
+name: SharedStorage (single node)
+
+# Single-node smoke test for the SharedStorage CRDT type: the context creator
+# is the sole writer and can set/read the shared config value, LWW-overwrite it,
+# and observe writer membership.
+#
+# Requires calimero-network/core#3340 (the js_crdt_shared_* host functions) in
+# the merod:edge image; runnable once #3340 merges and the image is rebuilt.
+# A concurrent multi-writer convergence workflow is deferred: adding a second
+# node as a writer needs its public key decoded in-guest, which the SDK does not
+# yet expose.
+
+force_pull_image: true
+
+nodes:
+  chain_id: testnet-1
+  count: 1
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: shared-storage-node
+
+steps:
+  - name: Install SharedStorage Application
+    type: install_application
+    node: shared-storage-node-1
+    path: 'examples/shared-storage/build/service.wasm'
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create Namespace
+    type: create_namespace
+    node: shared-storage-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create Context
+    type: create_context
+    node: shared-storage-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    params: '{}'
+    outputs:
+      context_id: contextId
+      member_public_key: memberPublicKey
+
+  # --- Creator is the sole writer ----------------------------------------
+  - name: Config Is Empty Before First Write
+    type: call
+    node: shared-storage-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: getConfig
+    outputs:
+      config_before: result.output
+
+  - name: Creator Can Write
+    type: call
+    node: shared-storage-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: canWrite
+    outputs:
+      can_write: result.output
+
+  - name: Set Config
+    type: call
+    node: shared-storage-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: setConfig
+    args:
+      value: hello
+
+  - name: Read Config
+    type: call
+    node: shared-storage-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: getConfig
+    outputs:
+      config_after: result.output
+
+  # --- Last-write-wins overwrite -----------------------------------------
+  - name: Overwrite Config
+    type: call
+    node: shared-storage-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: setConfig
+    args:
+      value: world
+
+  - name: Read Config Again
+    type: call
+    node: shared-storage-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: getConfig
+    outputs:
+      config_final: result.output
+
+  - name: Config Is Not Frozen
+    type: call
+    node: shared-storage-node-1
+    context_id: '{{context_id}}'
+    executor_public_key: '{{member_public_key}}'
+    method: isConfigFrozen
+    outputs:
+      is_frozen: result.output
+
+  - name: Assert Single-Writer Flow
+    type: json_assert
+    statements:
+      - 'equal({{config_before}}, null)'
+      - 'equal({{can_write}}, true)'
+      - 'equal({{config_after}}, "hello")'
+      - 'equal({{config_final}}, "world")'
+      - 'equal({{is_frozen}}, false)'
+
+stop_all_nodes: true
+restart: false
+wait_timeout: 120

--- a/packages/cli/builder/builder.c
+++ b/packages/cli/builder/builder.c
@@ -155,6 +155,14 @@ extern int32_t js_frozen_storage_new(uint64_t register_id);
 extern int32_t js_frozen_storage_add(uint64_t storage_id_buffer_ptr, uint64_t value_buffer_ptr, uint64_t register_id);
 extern int32_t js_frozen_storage_get(uint64_t storage_id_buffer_ptr, uint64_t hash_buffer_ptr, uint64_t register_id);
 extern int32_t js_frozen_storage_contains(uint64_t storage_id_buffer_ptr, uint64_t hash_buffer_ptr);
+extern int32_t js_crdt_shared_new(uint64_t writers_buffer_ptr, uint32_t frozen, uint64_t register_id);
+extern int32_t js_crdt_shared_new_with_id(uint64_t id_buffer_ptr, uint64_t writers_buffer_ptr, uint32_t frozen, uint64_t register_id);
+extern int32_t js_crdt_shared_set(uint64_t cell_id_buffer_ptr, uint64_t value_buffer_ptr);
+extern int32_t js_crdt_shared_get(uint64_t cell_id_buffer_ptr, uint64_t register_id);
+extern int32_t js_crdt_shared_writers(uint64_t cell_id_buffer_ptr, uint64_t register_id);
+extern int32_t js_crdt_shared_writable_by_me(uint64_t cell_id_buffer_ptr);
+extern int32_t js_crdt_shared_is_frozen(uint64_t cell_id_buffer_ptr);
+extern int32_t js_crdt_shared_rotate_writers(uint64_t cell_id_buffer_ptr, uint64_t writers_buffer_ptr);
 // PNCounter (signed PN-Counter). Provided by the node runtime (core#3318).
 extern int32_t js_crdt_pncounter_new(uint64_t register_id);
 extern int32_t js_crdt_pncounter_increment(uint64_t counter_id_buffer_ptr);
@@ -2673,6 +2681,176 @@ static JSValue js_env_frozen_storage_contains(JSContext *ctx, JSValueConst this_
   return JS_NewInt32(ctx, result);
 }
 
+// Wrapper: js_crdt_shared_new
+static JSValue js_env_crdt_shared_new(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+  (void)this_val;
+  if (argc < 3) {
+    return JS_ThrowTypeError(ctx, "js_crdt_shared_new expects writers, frozen, and register_id");
+  }
+  size_t writers_len;
+  uint8_t *writers_ptr = JSValueToUint8Array(ctx, argv[0], &writers_len);
+  if (!writers_ptr) {
+    return JS_EXCEPTION;
+  }
+  int64_t frozen;
+  if (js_to_i64(ctx, argv[1], &frozen) < 0) {
+    return JS_EXCEPTION;
+  }
+  int64_t register_id;
+  if (js_to_i64(ctx, argv[2], &register_id) < 0) {
+    return JS_EXCEPTION;
+  }
+  CalimeroBuffer writers_buf = make_buffer(writers_ptr, writers_len);
+  int32_t result = js_crdt_shared_new((uint64_t)&writers_buf, (uint32_t)frozen, (uint64_t)register_id);
+  return JS_NewInt32(ctx, result);
+}
+
+// Wrapper: js_crdt_shared_new_with_id
+static JSValue js_env_crdt_shared_new_with_id(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+  (void)this_val;
+  if (argc < 4) {
+    return JS_ThrowTypeError(ctx, "js_crdt_shared_new_with_id expects id, writers, frozen, and register_id");
+  }
+  size_t id_len;
+  uint8_t *id_ptr = JSValueToUint8Array(ctx, argv[0], &id_len);
+  if (!id_ptr || id_len != 32) {
+    return JS_ThrowRangeError(ctx, "id must be 32 bytes");
+  }
+  size_t writers_len;
+  uint8_t *writers_ptr = JSValueToUint8Array(ctx, argv[1], &writers_len);
+  if (!writers_ptr) {
+    return JS_EXCEPTION;
+  }
+  int64_t frozen;
+  if (js_to_i64(ctx, argv[2], &frozen) < 0) {
+    return JS_EXCEPTION;
+  }
+  int64_t register_id;
+  if (js_to_i64(ctx, argv[3], &register_id) < 0) {
+    return JS_EXCEPTION;
+  }
+  CalimeroBuffer id_buf = make_buffer(id_ptr, id_len);
+  CalimeroBuffer writers_buf = make_buffer(writers_ptr, writers_len);
+  int32_t result = js_crdt_shared_new_with_id((uint64_t)&id_buf, (uint64_t)&writers_buf, (uint32_t)frozen, (uint64_t)register_id);
+  return JS_NewInt32(ctx, result);
+}
+
+// Wrapper: js_crdt_shared_set
+static JSValue js_env_crdt_shared_set(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+  (void)this_val;
+  if (argc < 2) {
+    return JS_ThrowTypeError(ctx, "js_crdt_shared_set expects cellId and value");
+  }
+  size_t cell_id_len;
+  uint8_t *cell_id_ptr = JSValueToUint8Array(ctx, argv[0], &cell_id_len);
+  if (!cell_id_ptr || cell_id_len != 32) {
+    return JS_ThrowRangeError(ctx, "cellId must be 32 bytes");
+  }
+  size_t value_len;
+  uint8_t *value_ptr = JSValueToUint8Array(ctx, argv[1], &value_len);
+  if (!value_ptr) {
+    return JS_EXCEPTION;
+  }
+  CalimeroBuffer cell_id_buf = make_buffer(cell_id_ptr, cell_id_len);
+  CalimeroBuffer value_buf = make_buffer(value_ptr, value_len);
+  int32_t result = js_crdt_shared_set((uint64_t)&cell_id_buf, (uint64_t)&value_buf);
+  return JS_NewInt32(ctx, result);
+}
+
+// Wrapper: js_crdt_shared_get
+static JSValue js_env_crdt_shared_get(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+  (void)this_val;
+  if (argc < 2) {
+    return JS_ThrowTypeError(ctx, "js_crdt_shared_get expects cellId and register_id");
+  }
+  size_t cell_id_len;
+  uint8_t *cell_id_ptr = JSValueToUint8Array(ctx, argv[0], &cell_id_len);
+  if (!cell_id_ptr || cell_id_len != 32) {
+    return JS_ThrowRangeError(ctx, "cellId must be 32 bytes");
+  }
+  int64_t register_id;
+  if (js_to_i64(ctx, argv[1], &register_id) < 0) {
+    return JS_EXCEPTION;
+  }
+  CalimeroBuffer cell_id_buf = make_buffer(cell_id_ptr, cell_id_len);
+  int32_t result = js_crdt_shared_get((uint64_t)&cell_id_buf, (uint64_t)register_id);
+  return JS_NewInt32(ctx, result);
+}
+
+// Wrapper: js_crdt_shared_writers
+static JSValue js_env_crdt_shared_writers(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+  (void)this_val;
+  if (argc < 2) {
+    return JS_ThrowTypeError(ctx, "js_crdt_shared_writers expects cellId and register_id");
+  }
+  size_t cell_id_len;
+  uint8_t *cell_id_ptr = JSValueToUint8Array(ctx, argv[0], &cell_id_len);
+  if (!cell_id_ptr || cell_id_len != 32) {
+    return JS_ThrowRangeError(ctx, "cellId must be 32 bytes");
+  }
+  int64_t register_id;
+  if (js_to_i64(ctx, argv[1], &register_id) < 0) {
+    return JS_EXCEPTION;
+  }
+  CalimeroBuffer cell_id_buf = make_buffer(cell_id_ptr, cell_id_len);
+  int32_t result = js_crdt_shared_writers((uint64_t)&cell_id_buf, (uint64_t)register_id);
+  return JS_NewInt32(ctx, result);
+}
+
+// Wrapper: js_crdt_shared_writable_by_me
+static JSValue js_env_crdt_shared_writable_by_me(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+  (void)this_val;
+  if (argc < 1) {
+    return JS_ThrowTypeError(ctx, "js_crdt_shared_writable_by_me expects cellId");
+  }
+  size_t cell_id_len;
+  uint8_t *cell_id_ptr = JSValueToUint8Array(ctx, argv[0], &cell_id_len);
+  if (!cell_id_ptr || cell_id_len != 32) {
+    return JS_ThrowRangeError(ctx, "cellId must be 32 bytes");
+  }
+  CalimeroBuffer cell_id_buf = make_buffer(cell_id_ptr, cell_id_len);
+  int32_t result = js_crdt_shared_writable_by_me((uint64_t)&cell_id_buf);
+  return JS_NewInt32(ctx, result);
+}
+
+// Wrapper: js_crdt_shared_is_frozen
+static JSValue js_env_crdt_shared_is_frozen(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+  (void)this_val;
+  if (argc < 1) {
+    return JS_ThrowTypeError(ctx, "js_crdt_shared_is_frozen expects cellId");
+  }
+  size_t cell_id_len;
+  uint8_t *cell_id_ptr = JSValueToUint8Array(ctx, argv[0], &cell_id_len);
+  if (!cell_id_ptr || cell_id_len != 32) {
+    return JS_ThrowRangeError(ctx, "cellId must be 32 bytes");
+  }
+  CalimeroBuffer cell_id_buf = make_buffer(cell_id_ptr, cell_id_len);
+  int32_t result = js_crdt_shared_is_frozen((uint64_t)&cell_id_buf);
+  return JS_NewInt32(ctx, result);
+}
+
+// Wrapper: js_crdt_shared_rotate_writers
+static JSValue js_env_crdt_shared_rotate_writers(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+  (void)this_val;
+  if (argc < 2) {
+    return JS_ThrowTypeError(ctx, "js_crdt_shared_rotate_writers expects cellId and writers");
+  }
+  size_t cell_id_len;
+  uint8_t *cell_id_ptr = JSValueToUint8Array(ctx, argv[0], &cell_id_len);
+  if (!cell_id_ptr || cell_id_len != 32) {
+    return JS_ThrowRangeError(ctx, "cellId must be 32 bytes");
+  }
+  size_t writers_len;
+  uint8_t *writers_ptr = JSValueToUint8Array(ctx, argv[1], &writers_len);
+  if (!writers_ptr) {
+    return JS_EXCEPTION;
+  }
+  CalimeroBuffer cell_id_buf = make_buffer(cell_id_ptr, cell_id_len);
+  CalimeroBuffer writers_buf = make_buffer(writers_ptr, writers_len);
+  int32_t result = js_crdt_shared_rotate_writers((uint64_t)&cell_id_buf, (uint64_t)&writers_buf);
+  return JS_NewInt32(ctx, result);
+}
+
 // Wrapper: ed25519_verify
 static JSValue js_ed25519_verify(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
   if (argc < 3) {
@@ -2854,6 +3032,14 @@ void js_add_calimero_host_functions(JSContext *ctx) {
   JS_SetPropertyStr(ctx, env, "js_frozen_storage_add", JS_NewCFunction(ctx, js_env_frozen_storage_add, "js_frozen_storage_add", 3));
   JS_SetPropertyStr(ctx, env, "js_frozen_storage_get", JS_NewCFunction(ctx, js_env_frozen_storage_get, "js_frozen_storage_get", 3));
   JS_SetPropertyStr(ctx, env, "js_frozen_storage_contains", JS_NewCFunction(ctx, js_env_frozen_storage_contains, "js_frozen_storage_contains", 2));
+  JS_SetPropertyStr(ctx, env, "js_crdt_shared_new", JS_NewCFunction(ctx, js_env_crdt_shared_new, "js_crdt_shared_new", 3));
+  JS_SetPropertyStr(ctx, env, "js_crdt_shared_new_with_id", JS_NewCFunction(ctx, js_env_crdt_shared_new_with_id, "js_crdt_shared_new_with_id", 4));
+  JS_SetPropertyStr(ctx, env, "js_crdt_shared_set", JS_NewCFunction(ctx, js_env_crdt_shared_set, "js_crdt_shared_set", 2));
+  JS_SetPropertyStr(ctx, env, "js_crdt_shared_get", JS_NewCFunction(ctx, js_env_crdt_shared_get, "js_crdt_shared_get", 2));
+  JS_SetPropertyStr(ctx, env, "js_crdt_shared_writers", JS_NewCFunction(ctx, js_env_crdt_shared_writers, "js_crdt_shared_writers", 2));
+  JS_SetPropertyStr(ctx, env, "js_crdt_shared_writable_by_me", JS_NewCFunction(ctx, js_env_crdt_shared_writable_by_me, "js_crdt_shared_writable_by_me", 1));
+  JS_SetPropertyStr(ctx, env, "js_crdt_shared_is_frozen", JS_NewCFunction(ctx, js_env_crdt_shared_is_frozen, "js_crdt_shared_is_frozen", 1));
+  JS_SetPropertyStr(ctx, env, "js_crdt_shared_rotate_writers", JS_NewCFunction(ctx, js_env_crdt_shared_rotate_writers, "js_crdt_shared_rotate_writers", 2));
 
   // Opt-in root merge + deterministic-id CRDT constructors
   JS_SetPropertyStr(ctx, env, "register_js_sdk_root_merge", JS_NewCFunction(ctx, js_register_js_sdk_root_merge, "register_js_sdk_root_merge", 0));

--- a/packages/cli/src/abi/emitter.ts
+++ b/packages/cli/src/abi/emitter.ts
@@ -1541,6 +1541,14 @@ export class AbiEmitter {
           return this.extractTypeFromAnnotation({ typeAnnotation: type.typeParameters.params[0] });
         }
         break;
+      case 'SharedStorage':
+        // SharedStorage<V> wraps LwwRegister<Option<V>>; logical type is the
+        // inner value V (get() returns V | null), stored as a collection
+        // reference. Writer-set gating is a runtime concern, not an ABI shape.
+        if (type.typeParameters?.params?.length >= 1) {
+          return this.extractTypeFromAnnotation({ typeAnnotation: type.typeParameters.params[0] });
+        }
+        break;
       case 'FrozenStorage':
         // FrozenStorage<T> is internally UnorderedMap<Hash, FrozenValue<T>>
         // Hash is a 32-byte Uint8Array (content-addressable key)
@@ -2220,6 +2228,22 @@ export class AbiEmitter {
             kind: 'record',
             fields: [],
             crdt_type: 'lww_register',
+            inner_type: innerType,
+          };
+        }
+        break;
+      }
+      case 'SharedStorage': {
+        // SharedStorage<V> wraps LwwRegister<Option<V>>; carry the inner value
+        // type through, tagged so the host deserializer resolves the register.
+        if (type.typeParameters?.params?.length >= 1) {
+          const innerType = this.serializeTypeRefWithCrdtMetadata({
+            typeAnnotation: type.typeParameters.params[0],
+          });
+          return {
+            kind: 'record',
+            fields: [],
+            crdt_type: 'shared_storage',
             inner_type: innerType,
           };
         }

--- a/packages/sdk/src/__tests__/collections/SharedStorage.test.ts
+++ b/packages/sdk/src/__tests__/collections/SharedStorage.test.ts
@@ -1,0 +1,165 @@
+/**
+ * SharedStorage tests
+ */
+
+import '../setup';
+import { SharedStorage } from '../../collections/SharedStorage';
+import { clearStorage, setExecutorId, resetExecutorId } from '../setup';
+
+// Default mock executor is a 32-byte key of 0x01; a second member is 0x02.
+const ME = new Uint8Array(32).fill(1);
+const OTHER = new Uint8Array(32).fill(2);
+
+describe('SharedStorage', () => {
+  beforeEach(() => {
+    clearStorage();
+    resetExecutorId();
+  });
+
+  describe('construction', () => {
+    it('requires a writer set to create a cell', () => {
+      expect(() => new SharedStorage<string>({})).toThrow(/writers/i);
+    });
+
+    it('rejects a writer key that is not 32 bytes', () => {
+      expect(() => new SharedStorage<string>({ writers: [new Uint8Array(16)] })).toThrow();
+    });
+
+    it('accepts hex-string writer keys', () => {
+      const hex = Array.from(ME)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+      const cell = new SharedStorage<string>({ writers: [hex] });
+      expect(cell.writers()).toHaveLength(1);
+      expect(cell.writers()[0]).toEqual(ME);
+    });
+
+    it('creates a cell at a deterministic id when one is supplied', () => {
+      const id = new Uint8Array(32).fill(7);
+      const cell = new SharedStorage<string>({ writers: [ME], id });
+      expect(cell.idBytes()).toEqual(id);
+    });
+  });
+
+  describe('read / write', () => {
+    it('returns null before the first write', () => {
+      const cell = new SharedStorage<string>({ writers: [ME] });
+      expect(cell.get()).toBeNull();
+    });
+
+    it('round-trips a value through a writer', () => {
+      const cell = new SharedStorage<string>({ writers: [ME] });
+      cell.set('hello');
+      expect(cell.get()).toBe('hello');
+    });
+
+    it('round-trips a structured value', () => {
+      const cell = new SharedStorage<{ n: number; s: string }>({ writers: [ME] });
+      cell.set({ n: 42, s: 'x' });
+      expect(cell.get()).toEqual({ n: 42, s: 'x' });
+    });
+
+    it('overwrites on repeated set (last-write-wins)', () => {
+      const cell = new SharedStorage<string>({ writers: [ME] });
+      cell.set('a');
+      cell.set('b');
+      expect(cell.get()).toBe('b');
+    });
+  });
+
+  describe('writer gating', () => {
+    it('reports the current writer set', () => {
+      const cell = new SharedStorage<string>({ writers: [ME, OTHER] });
+      const writers = cell.writers();
+      expect(writers).toHaveLength(2);
+      expect(writers[0]).toEqual(ME);
+      expect(writers[1]).toEqual(OTHER);
+    });
+
+    it('reports writableByMe for a writer and a non-writer', () => {
+      const cell = new SharedStorage<string>({ writers: [ME] });
+      expect(cell.writableByMe()).toBe(true);
+      setExecutorId(OTHER);
+      expect(cell.writableByMe()).toBe(false);
+    });
+
+    it('rejects set from a non-writer', () => {
+      const cell = new SharedStorage<string>({ writers: [ME] });
+      setExecutorId(OTHER);
+      expect(() => cell.set('nope')).toThrow(/writer/i);
+    });
+  });
+
+  describe('writer rotation', () => {
+    it('lets a writer add a new writer, who can then write', () => {
+      const cell = new SharedStorage<string>({ writers: [ME] });
+      cell.rotateWriters([ME, OTHER]);
+      expect(cell.writers()).toHaveLength(2);
+
+      setExecutorId(OTHER);
+      expect(cell.writableByMe()).toBe(true);
+      cell.set('from-other');
+      expect(cell.get()).toBe('from-other');
+    });
+
+    it('can remove a writer, who then loses write access', () => {
+      const cell = new SharedStorage<string>({ writers: [ME, OTHER] });
+      cell.rotateWriters([ME]);
+
+      setExecutorId(OTHER);
+      expect(cell.writableByMe()).toBe(false);
+      expect(() => cell.set('nope')).toThrow(/writer/i);
+    });
+
+    it('rejects rotation from a non-writer', () => {
+      const cell = new SharedStorage<string>({ writers: [ME] });
+      setExecutorId(OTHER);
+      expect(() => cell.rotateWriters([OTHER])).toThrow(/writer/i);
+    });
+
+    it('rejects an empty writer set', () => {
+      const cell = new SharedStorage<string>({ writers: [ME] });
+      expect(() => cell.rotateWriters([])).toThrow();
+    });
+  });
+
+  describe('frozen cells', () => {
+    it('reports isFrozen', () => {
+      expect(new SharedStorage<string>({ writers: [ME] }).isFrozen()).toBe(false);
+      expect(new SharedStorage<string>({ writers: [ME], frozen: true }).isFrozen()).toBe(true);
+    });
+
+    it('rejects writes and rotation on a frozen cell', () => {
+      const cell = new SharedStorage<string>({ writers: [ME], frozen: true });
+      expect(cell.writableByMe()).toBe(false);
+      expect(() => cell.set('nope')).toThrow(/frozen/i);
+      expect(() => cell.rotateWriters([ME, OTHER])).toThrow(/frozen/i);
+    });
+  });
+
+  describe('identity & rehydration', () => {
+    it('exposes id() as hex and idBytes() as a copy', () => {
+      const cell = new SharedStorage<string>({ writers: [ME] });
+      expect(cell.id()).toMatch(/^[0-9a-f]{64}$/);
+      const bytes = cell.idBytes();
+      bytes[0] ^= 0xff;
+      expect(cell.idBytes()[0]).not.toBe(bytes[0]);
+    });
+
+    it('rehydrates via fromId and shares the same cell', () => {
+      const cell = new SharedStorage<string>({ writers: [ME] });
+      cell.set('shared');
+      const reopened = SharedStorage.fromId<string>(cell.idBytes());
+      expect(reopened.get()).toBe('shared');
+      expect(reopened.id()).toBe(cell.id());
+    });
+
+    it('serializes to a collection sentinel via toJSON', () => {
+      const cell = new SharedStorage<string>({ writers: [ME] });
+      expect(cell.toJSON()).toEqual({
+        __calimeroCollection: 'SharedStorage',
+        id: cell.id(),
+      });
+    });
+  });
+});

--- a/packages/sdk/src/__tests__/collections/SharedStorage.test.ts
+++ b/packages/sdk/src/__tests__/collections/SharedStorage.test.ts
@@ -21,6 +21,13 @@ describe('SharedStorage', () => {
       expect(() => new SharedStorage<string>({})).toThrow(/writers/i);
     });
 
+    it('rejects an empty writer set at construction (would brick the cell)', () => {
+      expect(() => new SharedStorage<string>({ writers: [] })).toThrow(/empty/i);
+      expect(
+        () => new SharedStorage<string>({ writers: [], id: new Uint8Array(32).fill(7) })
+      ).toThrow(/empty/i);
+    });
+
     it('rejects a writer key that is not 32 bytes', () => {
       expect(() => new SharedStorage<string>({ writers: [new Uint8Array(16)] })).toThrow();
     });

--- a/packages/sdk/src/__tests__/collections/SharedStorage.test.ts
+++ b/packages/sdk/src/__tests__/collections/SharedStorage.test.ts
@@ -27,7 +27,7 @@ describe('SharedStorage', () => {
 
     it('accepts hex-string writer keys', () => {
       const hex = Array.from(ME)
-        .map((b) => b.toString(16).padStart(2, '0'))
+        .map(b => b.toString(16).padStart(2, '0'))
         .join('');
       const cell = new SharedStorage<string>({ writers: [hex] });
       expect(cell.writers()).toHaveLength(1);

--- a/packages/sdk/src/__tests__/setup.ts
+++ b/packages/sdk/src/__tests__/setup.ts
@@ -209,7 +209,7 @@ function splitWriterKeys(buffer: Uint8Array): Uint8Array[] {
 }
 
 function executorIsWriter(store: SharedCellStore): boolean {
-  return store.writers.some((writer) => bytesEqual(writer, currentExecutorId));
+  return store.writers.some(writer => bytesEqual(writer, currentExecutorId));
 }
 
 // Mock env

--- a/packages/sdk/src/__tests__/setup.ts
+++ b/packages/sdk/src/__tests__/setup.ts
@@ -65,6 +65,15 @@ const sortedSets = new Map<string, SetStore>();
 const authoredMaps = new Map<string, AuthoredMapStore>();
 const authoredVectors = new Map<string, AuthoredVectorStore>();
 
+// Phase 2b SharedStorage: a group-writable single value with a rotatable writer
+// set. The mock enforces writer-gating against the current executor.
+type SharedCellStore = {
+  value: Uint8Array | null;
+  writers: Uint8Array[];
+  frozen: boolean;
+};
+const sharedCells = new Map<string, SharedCellStore>();
+
 // Lexicographic byte comparison for deterministic sorted iteration.
 function compareBytes(a: Uint8Array, b: Uint8Array): number {
   const len = Math.min(a.length, b.length);
@@ -189,6 +198,18 @@ function serializeMapEntries(entries: Array<[Uint8Array, Uint8Array]>): Uint8Arr
 function getExecutorKey(executor?: Uint8Array): string {
   const id = executor ?? currentExecutorId;
   return Array.from(id).join(',');
+}
+
+function splitWriterKeys(buffer: Uint8Array): Uint8Array[] {
+  const keys: Uint8Array[] = [];
+  for (let offset = 0; offset + 32 <= buffer.length; offset += 32) {
+    keys.push(buffer.slice(offset, offset + 32));
+  }
+  return keys;
+}
+
+function executorIsWriter(store: SharedCellStore): boolean {
+  return store.writers.some((writer) => bytesEqual(writer, currentExecutorId));
 }
 
 // Mock env
@@ -364,6 +385,118 @@ function getExecutorKey(executor?: Uint8Array): string {
   js_crdt_authored_vector_new_with_id: (id: Uint8Array, _register_id: bigint): number => {
     authoredVectors.set(idToKey(id), { slots: [] });
     setRegister(new Uint8Array(id));
+    return 0;
+  },
+
+  // --- SharedStorage (Phase 2b) --------------------------------------------
+  js_crdt_shared_new: (writers: Uint8Array, frozen: number, _register_id: bigint): number => {
+    const id = generateId();
+    sharedCells.set(idToKey(id), {
+      value: null,
+      writers: splitWriterKeys(writers),
+      frozen: frozen !== 0,
+    });
+    setRegister(new Uint8Array(id));
+    return 0;
+  },
+
+  js_crdt_shared_new_with_id: (
+    id: Uint8Array,
+    writers: Uint8Array,
+    frozen: number,
+    _register_id: bigint
+  ): number => {
+    sharedCells.set(idToKey(id), {
+      value: null,
+      writers: splitWriterKeys(writers),
+      frozen: frozen !== 0,
+    });
+    setRegister(new Uint8Array(id));
+    return 0;
+  },
+
+  js_crdt_shared_set: (cellId: Uint8Array, value: Uint8Array): number => {
+    const store = sharedCells.get(idToKey(cellId));
+    if (!store) {
+      setRegisterError('shared cell not found');
+      return -1;
+    }
+    if (store.frozen) {
+      setRegisterError('shared cell is frozen');
+      return -1;
+    }
+    if (!executorIsWriter(store)) {
+      setRegisterError('executor is not a writer');
+      return -1;
+    }
+    store.value = new Uint8Array(value);
+    return 0;
+  },
+
+  js_crdt_shared_get: (cellId: Uint8Array, _register_id: bigint): number => {
+    const store = sharedCells.get(idToKey(cellId));
+    if (!store) {
+      setRegisterError('shared cell not found');
+      return -1;
+    }
+    if (store.value === null) {
+      setRegister(null);
+      return 0;
+    }
+    setRegister(store.value);
+    return 1;
+  },
+
+  js_crdt_shared_writers: (cellId: Uint8Array, _register_id: bigint): number => {
+    const store = sharedCells.get(idToKey(cellId));
+    if (!store) {
+      setRegisterError('shared cell not found');
+      return -1;
+    }
+    const buffer = new Uint8Array(store.writers.length * 32);
+    store.writers.forEach((writer, index) => buffer.set(writer, index * 32));
+    setRegister(buffer);
+    return 1;
+  },
+
+  js_crdt_shared_writable_by_me: (cellId: Uint8Array): number => {
+    const store = sharedCells.get(idToKey(cellId));
+    if (!store) {
+      setRegisterError('shared cell not found');
+      return -1;
+    }
+    return executorIsWriter(store) && !store.frozen ? 1 : 0;
+  },
+
+  js_crdt_shared_is_frozen: (cellId: Uint8Array): number => {
+    const store = sharedCells.get(idToKey(cellId));
+    if (!store) {
+      setRegisterError('shared cell not found');
+      return -1;
+    }
+    return store.frozen ? 1 : 0;
+  },
+
+  js_crdt_shared_rotate_writers: (cellId: Uint8Array, writers: Uint8Array): number => {
+    const store = sharedCells.get(idToKey(cellId));
+    if (!store) {
+      setRegisterError('shared cell not found');
+      return -1;
+    }
+    if (store.frozen) {
+      setRegisterError('shared cell is frozen');
+      return -1;
+    }
+    if (!executorIsWriter(store)) {
+      setRegisterError('executor is not a writer');
+      return -1;
+    }
+    const next = splitWriterKeys(writers);
+    if (next.length === 0) {
+      setRegisterError('writer set must be non-empty');
+      return -1;
+    }
+    store.writers = next;
     return 0;
   },
 
@@ -1258,6 +1391,7 @@ export function clearStorage() {
   sortedSets.clear();
   authoredMaps.clear();
   authoredVectors.clear();
+  sharedCells.clear();
   resetExecutorId();
   currentRegister = null;
 }

--- a/packages/sdk/src/__tests__/utils/base58.test.ts
+++ b/packages/sdk/src/__tests__/utils/base58.test.ts
@@ -5,22 +5,15 @@
 import { bytesToBase58, base58ToBytes } from '../../env/api';
 
 describe('base58', () => {
-  it('decodes known single-digit values', () => {
-    // Non-leading-zero single digits: value = alphabet index.
+  it('decodes known standard-base58 values', () => {
+    expect(Array.from(base58ToBytes('1'))).toEqual([0]); // one leading '1' = one zero byte
+    expect(Array.from(base58ToBytes('11'))).toEqual([0, 0]); // no over-count
     expect(Array.from(base58ToBytes('2'))).toEqual([1]);
     expect(Array.from(base58ToBytes('z'))).toEqual([57]);
   });
 
-  it('is the exact inverse of bytesToBase58 for leading-zero keys', () => {
-    // decode ∘ encode is the identity for any key with a non-zero part — which
-    // covers every real public key (a 32-byte key is never all-zero). The
-    // encoder's all-zero edge (e.g. [0]) is a pre-existing quirk irrelevant to
-    // the writer-key path, so it is not exercised here.
-    for (const bytes of [
-      [0, 0, 42],
-      [0, 7, 0, 9],
-      [0, 255, 0, 1],
-    ]) {
+  it('is the exact inverse of bytesToBase58 (incl. all-zero and leading-zero keys)', () => {
+    for (const bytes of [[0], [0, 0], [0, 0, 42], [0, 7, 0, 9], [0, 255, 0, 1]]) {
       const key = new Uint8Array(bytes);
       expect(Array.from(base58ToBytes(bytesToBase58(key)))).toEqual(bytes);
     }
@@ -39,6 +32,18 @@ describe('base58', () => {
       key[0] = 0x07; // avoid all-zero so the shape varies
       expect(Array.from(base58ToBytes(bytesToBase58(key)))).toEqual(Array.from(key));
     }
+  });
+
+  it('decodes a 32-byte key with leading zero bytes to exactly 32 bytes', () => {
+    // The externally-produced case: a key starting with 0x00 has one leading '1'
+    // in standard base58 and must decode back to 32 bytes (not 33).
+    const key = new Uint8Array(32);
+    key[0] = 0x00;
+    key[1] = 0x00;
+    for (let i = 2; i < 32; i += 1) key[i] = (i * 53 + 7) & 0xff;
+    const decoded = base58ToBytes(bytesToBase58(key));
+    expect(decoded.length).toBe(32);
+    expect(Array.from(decoded)).toEqual(Array.from(key));
   });
 
   it('round-trips a random-looking key', () => {

--- a/packages/sdk/src/__tests__/utils/base58.test.ts
+++ b/packages/sdk/src/__tests__/utils/base58.test.ts
@@ -1,0 +1,53 @@
+/**
+ * base58 encode/decode round-trip tests.
+ */
+
+import { bytesToBase58, base58ToBytes } from '../../env/api';
+
+describe('base58', () => {
+  it('decodes known single-digit values', () => {
+    // Non-leading-zero single digits: value = alphabet index.
+    expect(Array.from(base58ToBytes('2'))).toEqual([1]);
+    expect(Array.from(base58ToBytes('z'))).toEqual([57]);
+  });
+
+  it('is the exact inverse of bytesToBase58 for leading-zero keys', () => {
+    // decode ∘ encode is the identity for any key with a non-zero part — which
+    // covers every real public key (a 32-byte key is never all-zero). The
+    // encoder's all-zero edge (e.g. [0]) is a pre-existing quirk irrelevant to
+    // the writer-key path, so it is not exercised here.
+    for (const bytes of [[0, 0, 42], [0, 7, 0, 9], [0, 255, 0, 1]]) {
+      const key = new Uint8Array(bytes);
+      expect(Array.from(base58ToBytes(bytesToBase58(key)))).toEqual(bytes);
+    }
+  });
+
+  it('preserves leading zero bytes as leading 1s', () => {
+    const bytes = new Uint8Array([0, 0, 5, 9]);
+    const s = bytesToBase58(bytes);
+    expect(s.startsWith('11')).toBe(true);
+    expect(Array.from(base58ToBytes(s))).toEqual([0, 0, 5, 9]);
+  });
+
+  it('round-trips 32-byte keys', () => {
+    for (const fill of [0x00, 0x01, 0xa1, 0xff]) {
+      const key = new Uint8Array(32).fill(fill);
+      key[0] = 0x07; // avoid all-zero so the shape varies
+      expect(Array.from(base58ToBytes(bytesToBase58(key)))).toEqual(Array.from(key));
+    }
+  });
+
+  it('round-trips a random-looking key', () => {
+    const key = new Uint8Array(32);
+    for (let i = 0; i < 32; i += 1) key[i] = (i * 37 + 11) & 0xff;
+    expect(Array.from(base58ToBytes(bytesToBase58(key)))).toEqual(Array.from(key));
+  });
+
+  it('throws on an invalid character', () => {
+    expect(() => base58ToBytes('0OIl')).toThrow(/invalid base58/i); // 0,O,I,l are not in the alphabet
+  });
+
+  it('returns empty for an empty string', () => {
+    expect(base58ToBytes('')).toEqual(new Uint8Array(0));
+  });
+});

--- a/packages/sdk/src/__tests__/utils/base58.test.ts
+++ b/packages/sdk/src/__tests__/utils/base58.test.ts
@@ -16,7 +16,11 @@ describe('base58', () => {
     // covers every real public key (a 32-byte key is never all-zero). The
     // encoder's all-zero edge (e.g. [0]) is a pre-existing quirk irrelevant to
     // the writer-key path, so it is not exercised here.
-    for (const bytes of [[0, 0, 42], [0, 7, 0, 9], [0, 255, 0, 1]]) {
+    for (const bytes of [
+      [0, 0, 42],
+      [0, 7, 0, 9],
+      [0, 255, 0, 1],
+    ]) {
       const key = new Uint8Array(bytes);
       expect(Array.from(base58ToBytes(bytesToBase58(key)))).toEqual(bytes);
     }

--- a/packages/sdk/src/collections/SharedStorage.ts
+++ b/packages/sdk/src/collections/SharedStorage.ts
@@ -1,0 +1,192 @@
+/**
+ * SharedStorage - group-writable single value with a rotatable writer set.
+ *
+ * Wraps the Rust `JsSharedStorage` host functions landed in
+ * calimero-network/core#3340. A SharedStorage cell holds a single byte value in
+ * an LWW register that any member of its *writer set* may overwrite:
+ *
+ *  - `set(value)` and `rotateWriters(writers)` are **writer-gated**: the host
+ *    rejects a non-writer executor ("Executor is not authorised…"), surfaced
+ *    here as a thrown error. The executor identity is host-provided.
+ *  - `get()` returns `null` until the value is first written.
+ *  - `writers()` returns the current writer set (32-byte public keys).
+ *  - `writableByMe()`/`isFrozen()` report writer membership and the frozen flag.
+ *
+ * A missing cell cannot be lazily recreated (its writer set is unknown), so a
+ * cell must be constructed via `new SharedStorage({ writers })` (fresh, random
+ * id), `new SharedStorage({ writers, id })` (deterministic id) or rehydrated
+ * from a persisted snapshot via {@link SharedStorage.fromId}. Calling `get`/
+ * `set`/etc. on an id that was never opened surfaces a host error.
+ *
+ * Writer keys are passed as raw 32-byte `Uint8Array` public keys (what the host
+ * wants — e.g. the value returned by `env.executorId()`) or as 64-character hex
+ * strings; both are normalized to raw 32-byte keys before crossing the ABI. The
+ * writer set crosses the ABI as the concatenation of those 32-byte keys.
+ */
+
+import { serialize, deserialize } from '../utils/serialize';
+import { bytesToHex, normalizeCollectionId } from '../utils/hex';
+import {
+  sharedNew,
+  sharedNewWithId,
+  sharedSet,
+  sharedGet,
+  sharedWriters,
+  sharedWritableByMe,
+  sharedIsFrozen,
+  sharedRotateWriters,
+} from '../runtime/storage-wasm';
+import { registerCollectionType, CollectionSnapshot } from '../runtime/collections';
+
+const SENTINEL_KEY = '__calimeroCollection';
+const PUBLIC_KEY_LENGTH = 32;
+
+/**
+ * A writer public key: a raw 32-byte `Uint8Array` or a 64-character hex string.
+ */
+export type WriterKey = Uint8Array | string;
+
+export interface SharedStorageOptions {
+  /**
+   * The initial writer set — raw 32-byte public keys or 64-character hex
+   * strings. Required when creating a cell (omit only via {@link
+   * SharedStorage.fromId}, which rehydrates an already-opened cell).
+   */
+  writers?: WriterKey[];
+  /**
+   * Whether the cell is created frozen. Defaults to `false`.
+   */
+  frozen?: boolean;
+  /**
+   * Existing/deterministic cell identifier as a 32-byte Uint8Array or
+   * 64-character hex string. With `writers` present, the cell is (re)opened at
+   * this id; without `writers`, the id is wrapped as-is (snapshot rehydrate).
+   */
+  id?: Uint8Array | string;
+}
+
+/**
+ * Normalize a single writer key to a raw 32-byte `Uint8Array`.
+ */
+function normalizeWriter(key: WriterKey): Uint8Array {
+  return normalizeCollectionId(key, 'SharedStorage writer');
+}
+
+/**
+ * Concatenate normalized writer keys into the `count * 32` byte encoding the
+ * host expects.
+ */
+function encodeWriters(writers: WriterKey[]): Uint8Array {
+  const normalized = writers.map(normalizeWriter);
+  const buffer = new Uint8Array(normalized.length * PUBLIC_KEY_LENGTH);
+  normalized.forEach((key, index) => {
+    buffer.set(key, index * PUBLIC_KEY_LENGTH);
+  });
+  return buffer;
+}
+
+export class SharedStorage<V> {
+  private readonly cellId: Uint8Array;
+
+  constructor(options: SharedStorageOptions = {}) {
+    const { writers, frozen = false, id } = options;
+
+    if (writers === undefined) {
+      // Rehydrate an already-opened cell from its id (e.g. a persisted
+      // snapshot). No host call: the cell is assumed to exist.
+      if (id === undefined) {
+        throw new Error('SharedStorage: `writers` is required to create a cell');
+      }
+      this.cellId = normalizeCollectionId(id, 'SharedStorage');
+      return;
+    }
+
+    const encodedWriters = encodeWriters(writers);
+    if (id === undefined) {
+      // Fresh cell at a host-assigned random id.
+      this.cellId = sharedNew(encodedWriters, frozen);
+    } else {
+      // Cell at a caller-supplied (deterministic) id.
+      const normalizedId = normalizeCollectionId(id, 'SharedStorage');
+      this.cellId = sharedNewWithId(normalizedId, encodedWriters, frozen);
+    }
+  }
+
+  /**
+   * Rehydrate an already-opened cell from its id (no host call). Used by the
+   * snapshot loader; operations error if the cell was never opened.
+   */
+  static fromId<V>(id: Uint8Array | string): SharedStorage<V> {
+    return new SharedStorage<V>({ id });
+  }
+
+  /**
+   * Returns the underlying cell identifier as a hex string.
+   */
+  id(): string {
+    return bytesToHex(this.cellId);
+  }
+
+  /**
+   * Returns a copy of the cell identifier bytes.
+   */
+  idBytes(): Uint8Array {
+    return new Uint8Array(this.cellId);
+  }
+
+  /**
+   * Overwrites the stored value. **Writer-gated**: throws when the current
+   * executor is not a member of the writer set.
+   */
+  set(value: V): void {
+    sharedSet(this.cellId, serialize(value));
+  }
+
+  /**
+   * Returns the stored value, or `null` when the cell has never been written.
+   */
+  get(): V | null {
+    const raw = sharedGet(this.cellId);
+    return raw ? deserialize<V>(raw) : null;
+  }
+
+  /**
+   * Returns the current writer set as raw 32-byte public keys.
+   */
+  writers(): Uint8Array[] {
+    return sharedWriters(this.cellId);
+  }
+
+  /**
+   * Reports whether the current executor may write to this cell.
+   */
+  writableByMe(): boolean {
+    return sharedWritableByMe(this.cellId);
+  }
+
+  /**
+   * Reports whether the cell was created frozen.
+   */
+  isFrozen(): boolean {
+    return sharedIsFrozen(this.cellId);
+  }
+
+  /**
+   * Replaces the writer set. **Writer-gated**: throws when the current executor
+   * is not a member of the *current* writer set.
+   */
+  rotateWriters(writers: WriterKey[]): void {
+    sharedRotateWriters(this.cellId, encodeWriters(writers));
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      [SENTINEL_KEY]: 'SharedStorage',
+      id: this.id(),
+    };
+  }
+}
+
+registerCollectionType('SharedStorage', (snapshot: CollectionSnapshot) =>
+  SharedStorage.fromId(snapshot.id)
+);

--- a/packages/sdk/src/collections/SharedStorage.ts
+++ b/packages/sdk/src/collections/SharedStorage.ts
@@ -58,9 +58,15 @@ export interface SharedStorageOptions {
    */
   frozen?: boolean;
   /**
-   * Existing/deterministic cell identifier as a 32-byte Uint8Array or
-   * 64-character hex string. With `writers` present, the cell is (re)opened at
-   * this id; without `writers`, the id is wrapped as-is (snapshot rehydrate).
+   * A 32-byte Uint8Array or 64-character hex cell identifier.
+   *
+   * With `writers` present, a cell is **created/registered at this exact id**
+   * with the given writer set — use it for a stable, cross-node id at genesis
+   * (this is how deterministic `@State` fields are assigned). It is **not** a
+   * safe reopen of an existing cell: to reopen a cell that already holds data
+   * without touching its value or writer set, use {@link SharedStorage.fromId}
+   * (or `new SharedStorage({ id })` with no `writers`), which wraps the id with
+   * no host call.
    */
   id?: Uint8Array | string;
 }
@@ -74,9 +80,16 @@ function normalizeWriter(key: WriterKey): Uint8Array {
 
 /**
  * Concatenate normalized writer keys into the `count * 32` byte encoding the
- * host expects.
+ * host expects. Rejects an empty writer set: a cell with no writers could never
+ * be written to (`set`/`rotateWriters` are writer-gated) and `rotateWriters`
+ * refuses an empty set, so it could never be recovered — it would be bricked.
  */
 function encodeWriters(writers: WriterKey[]): Uint8Array {
+  if (writers.length === 0) {
+    throw new Error(
+      'SharedStorage: writer set must not be empty — a cell with no writers can never be written to or recovered'
+    );
+  }
   const normalized = writers.map(normalizeWriter);
   const buffer = new Uint8Array(normalized.length * PUBLIC_KEY_LENGTH);
   normalized.forEach((key, index) => {

--- a/packages/sdk/src/collections/index.ts
+++ b/packages/sdk/src/collections/index.ts
@@ -23,3 +23,4 @@ export { AuthoredVector, type AuthoredVectorOptions } from './AuthoredVector';
 // Specialized Storage Collections
 export { UserStorage, type UserStorageOptions, type PublicKey } from './UserStorage';
 export { FrozenStorage, FrozenValue, type FrozenStorageOptions, type Hash } from './FrozenStorage';
+export { SharedStorage, type SharedStorageOptions, type WriterKey } from './SharedStorage';

--- a/packages/sdk/src/env/api.ts
+++ b/packages/sdk/src/env/api.ts
@@ -395,7 +395,7 @@ export function executorIdBase58(): string {
   return bytesToBase58(id);
 }
 
-function bytesToBase58(bytes: Uint8Array): string {
+export function bytesToBase58(bytes: Uint8Array): string {
   const alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
   if (bytes.length === 0) {
     return '';
@@ -425,6 +425,44 @@ function bytesToBase58(bytes: Uint8Array): string {
     .reverse()
     .map(digit => alphabet[digit])
     .join('');
+}
+
+/**
+ * Decode a base58 string into bytes — the inverse of the encoding used by
+ * {@link executorIdBase58}. Useful when a public key arrives as base58 (e.g. a
+ * member key surfaced by tooling) and must be handed to an API expecting raw
+ * bytes, such as a SharedStorage writer set. Throws on an invalid character.
+ */
+export function base58ToBytes(value: string): Uint8Array {
+  const alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+  if (value.length === 0) {
+    return new Uint8Array(0);
+  }
+
+  const bytes: number[] = [0];
+  for (let i = 0; i < value.length; i += 1) {
+    const digit = alphabet.indexOf(value[i]);
+    if (digit === -1) {
+      throw new Error(`base58ToBytes: invalid base58 character '${value[i]}'`);
+    }
+    let carry = digit;
+    for (let j = 0; j < bytes.length; j += 1) {
+      const x = bytes[j] * 58 + carry;
+      bytes[j] = x & 0xff;
+      carry = x >> 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  // Each leading '1' in base58 encodes a leading zero byte.
+  for (let i = 0; i < value.length && value[i] === '1'; i += 1) {
+    bytes.push(0);
+  }
+
+  return new Uint8Array(bytes.reverse());
 }
 
 /**

--- a/packages/sdk/src/env/api.ts
+++ b/packages/sdk/src/env/api.ts
@@ -395,13 +395,19 @@ export function executorIdBase58(): string {
   return bytesToBase58(id);
 }
 
+/** Bitcoin/standard base58 alphabet (no 0, O, I, l). */
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
 export function bytesToBase58(bytes: Uint8Array): string {
-  const alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+  const alphabet = BASE58_ALPHABET;
   if (bytes.length === 0) {
     return '';
   }
 
-  const digits: number[] = [0];
+  // Standard base58: an empty accumulator, so a zero-valued number encodes to no
+  // digits and leading zero bytes are added separately as leading '1's below
+  // (an initial [0] would double-count an all-zero input).
+  const digits: number[] = [];
 
   for (let i = 0; i < bytes.length; i += 1) {
     let carry = bytes[i];
@@ -434,12 +440,15 @@ export function bytesToBase58(bytes: Uint8Array): string {
  * bytes, such as a SharedStorage writer set. Throws on an invalid character.
  */
 export function base58ToBytes(value: string): Uint8Array {
-  const alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+  const alphabet = BASE58_ALPHABET;
   if (value.length === 0) {
     return new Uint8Array(0);
   }
 
-  const bytes: number[] = [0];
+  // Standard base58: an empty accumulator so leading '1's map one-to-one to
+  // leading zero bytes. An initial [0] would over-count by one zero byte,
+  // mis-decoding externally-produced strings whose bytes are all zero.
+  const bytes: number[] = [];
   for (let i = 0; i < value.length; i += 1) {
     const digit = alphabet.indexOf(value[i]);
     if (digit === -1) {

--- a/packages/sdk/src/env/api.ts
+++ b/packages/sdk/src/env/api.ts
@@ -1023,6 +1023,43 @@ export function jsFrozenStorageContains(storageId: Uint8Array, hash: Uint8Array)
   return env.js_frozen_storage_contains(storageId, hash);
 }
 
+export function jsCrdtSharedNew(writers: Uint8Array, frozen: number, register: bigint): number {
+  return env.js_crdt_shared_new(writers, frozen, register);
+}
+
+export function jsCrdtSharedNewWithId(
+  id: Uint8Array,
+  writers: Uint8Array,
+  frozen: number,
+  register: bigint
+): number {
+  return env.js_crdt_shared_new_with_id(id, writers, frozen, register);
+}
+
+export function jsCrdtSharedSet(cellId: Uint8Array, value: Uint8Array): number {
+  return env.js_crdt_shared_set(cellId, value);
+}
+
+export function jsCrdtSharedGet(cellId: Uint8Array, register: bigint): number {
+  return env.js_crdt_shared_get(cellId, register);
+}
+
+export function jsCrdtSharedWriters(cellId: Uint8Array, register: bigint): number {
+  return env.js_crdt_shared_writers(cellId, register);
+}
+
+export function jsCrdtSharedWritableByMe(cellId: Uint8Array): number {
+  return env.js_crdt_shared_writable_by_me(cellId);
+}
+
+export function jsCrdtSharedIsFrozen(cellId: Uint8Array): number {
+  return env.js_crdt_shared_is_frozen(cellId);
+}
+
+export function jsCrdtSharedRotateWriters(cellId: Uint8Array, writers: Uint8Array): number {
+  return env.js_crdt_shared_rotate_writers(cellId, writers);
+}
+
 /**
  * Flush pending delta actions to the host.
  *

--- a/packages/sdk/src/env/bindings.ts
+++ b/packages/sdk/src/env/bindings.ts
@@ -182,6 +182,23 @@ export interface HostEnv {
   js_frozen_storage_get(storageId: Uint8Array, hash: Uint8Array, register_id: bigint): number;
   js_frozen_storage_contains(storageId: Uint8Array, hash: Uint8Array): number;
 
+  // SharedStorage (group-writable single value with a rotatable writer set).
+  // `writers` crosses as the concatenation of 32-byte public keys; `frozen` is a
+  // u32 bool. Set/rotate return -1 with the error in register 0 for a non-writer.
+  js_crdt_shared_new(writers: Uint8Array, frozen: number, register_id: bigint): number;
+  js_crdt_shared_new_with_id(
+    id: Uint8Array,
+    writers: Uint8Array,
+    frozen: number,
+    register_id: bigint
+  ): number;
+  js_crdt_shared_set(cellId: Uint8Array, value: Uint8Array): number;
+  js_crdt_shared_get(cellId: Uint8Array, register_id: bigint): number;
+  js_crdt_shared_writers(cellId: Uint8Array, register_id: bigint): number;
+  js_crdt_shared_writable_by_me(cellId: Uint8Array): number;
+  js_crdt_shared_is_frozen(cellId: Uint8Array): number;
+  js_crdt_shared_rotate_writers(cellId: Uint8Array, writers: Uint8Array): number;
+
   // Context
   context_id(register_id: bigint): void;
   executor_id(register_id: bigint): void;

--- a/packages/sdk/src/runtime/deterministic-ids.ts
+++ b/packages/sdk/src/runtime/deterministic-ids.ts
@@ -14,7 +14,7 @@
  */
 
 import * as env from '../env/api';
-import { bytesToHex } from '../utils/hex';
+import { bytesToHex, hexToBytes } from '../utils/hex';
 import { computeCollectionId, ROOT_ID } from '../utils/deterministic-id';
 import { snapshotCollection, instantiateCollection } from './collections';
 import {
@@ -31,9 +31,34 @@ import {
   authoredVectorNewWithId,
   userStorageNewWithId,
   frozenStorageNewWithId,
+  sharedNewWithId,
+  sharedWriters,
+  sharedIsFrozen,
 } from './storage-wasm';
 
 type WithIdFn = (id: Uint8Array) => Uint8Array;
+
+const SHARED_WRITER_KEY_LENGTH = 32;
+
+/**
+ * Re-open a SharedStorage cell at a deterministic id. Unlike the other
+ * collections, SharedStorage carries construction state (its writer set and the
+ * frozen flag), so it cannot be created from an id alone — we read that state
+ * off the freshly-constructed (random-id) cell and recreate it at the
+ * deterministic id. Writer sets are identical public keys across nodes, so the
+ * recreated cell converges. Runs only on fresh state, so the source cell is
+ * empty and nothing is lost.
+ */
+function reopenSharedAt(currentHex: string, expectedId: Uint8Array): void {
+  const currentId = hexToBytes(currentHex);
+  const keys = sharedWriters(currentId);
+  const frozen = sharedIsFrozen(currentId);
+  const encoded = new Uint8Array(keys.length * SHARED_WRITER_KEY_LENGTH);
+  keys.forEach((key, index) => {
+    encoded.set(key, index * SHARED_WRITER_KEY_LENGTH);
+  });
+  sharedNewWithId(expectedId, encoded, frozen);
+}
 
 const WITH_ID: Record<string, WithIdFn> = {
   UnorderedMap: mapNewWithId,
@@ -70,8 +95,9 @@ export function assignDeterministicIds(state: unknown): void {
       continue;
     }
 
+    const isShared = snapshot.type === 'SharedStorage';
     const withId = WITH_ID[snapshot.type];
-    if (!withId) {
+    if (!withId && !isShared) {
       // Unknown/unsupported collection type — leave it untouched.
       continue;
     }
@@ -85,8 +111,13 @@ export function assignDeterministicIds(state: unknown): void {
 
     // Create/re-open the entity at the deterministic id in the host, then swap
     // the field to a collection wrapping that id. The previous random-id entity
-    // is orphaned (safe: fresh collections are empty).
-    withId(expectedId);
+    // is orphaned (safe: fresh collections are empty). SharedStorage needs its
+    // writer set/frozen flag carried across; other collections re-open from id.
+    if (isShared) {
+      reopenSharedAt(snapshot.id, expectedId);
+    } else {
+      withId!(expectedId);
+    }
     target[key] = instantiateCollection({ type: snapshot.type, id: expectedHex });
     env.log(
       `[deterministic-ids] field '${key}' (${snapshot.type}) -> ${expectedHex.slice(0, 16)}…`

--- a/packages/sdk/src/runtime/deterministic-ids.ts
+++ b/packages/sdk/src/runtime/deterministic-ids.ts
@@ -45,9 +45,17 @@ const SHARED_WRITER_KEY_LENGTH = 32;
  * collections, SharedStorage carries construction state (its writer set and the
  * frozen flag), so it cannot be created from an id alone — we read that state
  * off the freshly-constructed (random-id) cell and recreate it at the
- * deterministic id. Writer sets are identical public keys across nodes, so the
- * recreated cell converges. Runs only on fresh state, so the source cell is
- * empty and nothing is lost.
+ * deterministic id.
+ *
+ * Safety rests on the same contract {@link assignDeterministicIds} relies on for
+ * every collection: reassignment runs *only* on fresh state (genesis / first
+ * init), which in practice is the context creator. Joining nodes do not
+ * reconstruct the field — they hydrate it from the synced snapshot — so the
+ * creator's writer set is the single authoritative one and does not diverge
+ * across nodes (even though a per-node `executorId()` writer would differ if two
+ * nodes each ran init). And because the source cell is empty at this point (the
+ * fresh-state contract), carrying only the writer set / frozen flag — not a
+ * value — loses nothing.
  */
 function reopenSharedAt(currentHex: string, expectedId: Uint8Array): void {
   const currentId = hexToBytes(currentHex);

--- a/packages/sdk/src/runtime/storage-wasm.ts
+++ b/packages/sdk/src/runtime/storage-wasm.ts
@@ -103,6 +103,14 @@ import {
   jsFrozenStorageAdd,
   jsFrozenStorageGet,
   jsFrozenStorageContains,
+  jsCrdtSharedNew,
+  jsCrdtSharedNewWithId,
+  jsCrdtSharedSet,
+  jsCrdtSharedGet,
+  jsCrdtSharedWriters,
+  jsCrdtSharedWritableByMe,
+  jsCrdtSharedIsFrozen,
+  jsCrdtSharedRotateWriters,
 } from '../env/api';
 
 const REGISTER_ID = 0n;
@@ -1552,4 +1560,111 @@ export function frozenStorageContains(storageId: Uint8Array, hash: Uint8Array): 
   }
 
   return status === 1;
+}
+
+// --- SharedStorage: group-writable single value with a rotatable writer set ---
+
+const SHARED_WRITER_KEY_LENGTH = 32;
+
+function ensureWriters(writers: Uint8Array): void {
+  ensureUint8Array(writers, 'writers');
+  if (writers.length === 0 || writers.length % SHARED_WRITER_KEY_LENGTH !== 0) {
+    throw new TypeError(
+      `writers must be a non-empty multiple of ${SHARED_WRITER_KEY_LENGTH} bytes (got ${writers.length})`
+    );
+  }
+}
+
+export function sharedNew(writers: Uint8Array, frozen: boolean): Uint8Array {
+  ensureWriters(writers);
+  const status = Number(jsCrdtSharedNew(writers, frozen ? 1 : 0, REGISTER_ID));
+  if (status < 0) {
+    decodeError('sharedNew');
+  }
+  const id = readRegisterBytes();
+  if (id.length !== COLLECTION_ID_LENGTH) {
+    throw new Error(`[storage] sharedNew returned invalid id length (${id.length})`);
+  }
+  return id;
+}
+
+export function sharedNewWithId(id: Uint8Array, writers: Uint8Array, frozen: boolean): Uint8Array {
+  ensureCollectionId(id, 'sharedNewWithId.id');
+  ensureWriters(writers);
+  const status = Number(jsCrdtSharedNewWithId(id, writers, frozen ? 1 : 0, REGISTER_ID));
+  if (status < 0) {
+    decodeError('sharedNewWithId');
+  }
+  const returnedId = readRegisterBytes();
+  if (returnedId.length !== COLLECTION_ID_LENGTH) {
+    throw new Error(`[storage] sharedNewWithId returned invalid id length (${returnedId.length})`);
+  }
+  return returnedId;
+}
+
+export function sharedSet(cellId: Uint8Array, value: Uint8Array): void {
+  ensureCollectionId(cellId, 'cellId');
+  ensureUint8Array(value, 'value');
+  const status = Number(jsCrdtSharedSet(cellId, value));
+  if (status < 0) {
+    decodeError('sharedSet');
+  }
+}
+
+export function sharedGet(cellId: Uint8Array): Uint8Array | null {
+  ensureCollectionId(cellId, 'cellId');
+  const status = Number(jsCrdtSharedGet(cellId, REGISTER_ID));
+  if (status < 0) {
+    decodeError('sharedGet');
+  }
+  if (status === 0) {
+    return null;
+  }
+  return readRegisterBytes();
+}
+
+export function sharedWriters(cellId: Uint8Array): Uint8Array[] {
+  ensureCollectionId(cellId, 'cellId');
+  const status = Number(jsCrdtSharedWriters(cellId, REGISTER_ID));
+  if (status < 0) {
+    decodeError('sharedWriters');
+  }
+  const concatenated = readRegisterBytes();
+  if (concatenated.length % SHARED_WRITER_KEY_LENGTH !== 0) {
+    throw new Error(
+      `[storage] sharedWriters returned ${concatenated.length} bytes (not a multiple of ${SHARED_WRITER_KEY_LENGTH})`
+    );
+  }
+  const keys: Uint8Array[] = [];
+  for (let off = 0; off < concatenated.length; off += SHARED_WRITER_KEY_LENGTH) {
+    keys.push(concatenated.slice(off, off + SHARED_WRITER_KEY_LENGTH));
+  }
+  return keys;
+}
+
+export function sharedWritableByMe(cellId: Uint8Array): boolean {
+  ensureCollectionId(cellId, 'cellId');
+  const status = Number(jsCrdtSharedWritableByMe(cellId));
+  if (status < 0) {
+    decodeError('sharedWritableByMe');
+  }
+  return status === 1;
+}
+
+export function sharedIsFrozen(cellId: Uint8Array): boolean {
+  ensureCollectionId(cellId, 'cellId');
+  const status = Number(jsCrdtSharedIsFrozen(cellId));
+  if (status < 0) {
+    decodeError('sharedIsFrozen');
+  }
+  return status === 1;
+}
+
+export function sharedRotateWriters(cellId: Uint8Array, writers: Uint8Array): void {
+  ensureCollectionId(cellId, 'cellId');
+  ensureWriters(writers);
+  const status = Number(jsCrdtSharedRotateWriters(cellId, writers));
+  if (status < 0) {
+    decodeError('sharedRotateWriters');
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,25 +14,25 @@ importers:
     devDependencies:
       '@semantic-release/exec':
         specifier: ^7.0.0
-        version: 7.1.0(semantic-release@25.0.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
+        version: 7.1.0(semantic-release@25.0.2(typescript@5.9.3))
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.24
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.15.0
-        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^6.15.0
-        version: 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 6.21.0(eslint@8.57.1)(typescript@5.9.3)
       conventional-changelog-conventionalcommits:
         specifier: ^7.0.0
         version: 7.0.2
       eslint:
         specifier: ^8.56.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.2(eslint@8.57.1(supports-color@8.1.1))
+        version: 9.1.2(eslint@8.57.1)
       prettier:
         specifier: ^3.1.1
         version: 3.6.2
@@ -176,6 +176,19 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
 
+  examples/shared-storage:
+    dependencies:
+      '@calimero-network/calimero-sdk-js':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+    devDependencies:
+      '@calimero-network/calimero-cli-js':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
   examples/state-schema-conformance:
     dependencies:
       '@calimero-network/calimero-sdk-js':
@@ -222,19 +235,19 @@ importers:
     dependencies:
       '@babel/core':
         specifier: ^7.29.6
-        version: 7.29.6(supports-color@8.1.1)
+        version: 7.29.6
       '@babel/parser':
         specifier: ^7.23.6
         version: 7.28.5
       '@babel/preset-env':
         specifier: ^7.23.6
-        version: 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.28.5(@babel/core@7.29.6)
       '@babel/traverse':
         specifier: ^7.23.6
-        version: 7.28.5(supports-color@8.1.1)
+        version: 7.28.5
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.1.0(@babel/core@7.29.6(supports-color@8.1.1))(@types/babel__core@7.20.5)(rollup@4.52.5)(supports-color@8.1.1)
+        version: 6.1.0(@babel/core@7.29.6)(@types/babel__core@7.20.5)(rollup@4.52.5)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.7
         version: 25.0.8(rollup@4.52.5)
@@ -271,10 +284,10 @@ importers:
         version: 1.4.7
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.24)(supports-color@8.1.1)
+        version: 29.7.0(@types/node@20.19.24)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.5(@babel/core@7.29.6(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.24)(supports-color@8.1.1))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.29.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.24))(typescript@5.9.3)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -293,10 +306,10 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.24)(supports-color@8.1.1)
+        version: 29.7.0(@types/node@20.19.24)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.5(@babel/core@7.29.6(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.24)(supports-color@8.1.1))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.29.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.24))(typescript@5.9.3)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -1245,67 +1258,56 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -2158,12 +2160,12 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -3598,20 +3600,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.6(supports-color@8.1.1)':
+  '@babel/core@7.29.6':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3654,32 +3656,32 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.6)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -3689,42 +3691,42 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-member-expression-to-functions@7.28.5(supports-color@8.1.1)':
+  '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.27.1(supports-color@8.1.1)':
+  '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.29.7(supports-color@8.1.1)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -3734,27 +3736,27 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-wrap-function': 7.28.3(supports-color@8.1.1)
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-wrap-function': 7.28.3
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-replace-supers@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1(supports-color@8.1.1)':
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -3771,10 +3773,10 @@ snapshots:
 
   '@babel/helper-validator-option@7.29.7': {}
 
-  '@babel/helper-wrap-function@7.28.3(supports-color@8.1.1)':
+  '@babel/helper-wrap-function@7.28.3':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -3792,553 +3794,553 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
-      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.4(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.28.4(@babel/core@7.29.6)':
+    dependencies:
+      '@babel/core': 7.29.6
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.6)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.27.2
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-exponentiation-operator@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.6)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.29.6)':
+    dependencies:
+      '@babel/core': 7.29.6
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/preset-env@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/preset-env@7.28.5(@babel/core@7.29.6)':
     dependencies:
       '@babel/compat-data': 7.28.5
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-block-scoping': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-modules-systemjs': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-regenerator': 7.28.4(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.6(supports-color@8.1.1))
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.6)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.29.6)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6)
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.29.6)
+      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-block-scoping': 7.28.5(@babel/core@7.29.6)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.29.6)
+      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.29.6)
+      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6)
+      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.29.6)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.5(@babel/core@7.29.6)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.5(@babel/core@7.29.6)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-modules-systemjs': 7.28.5(@babel/core@7.29.6)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.29.6)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.6)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6)
+      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-regenerator': 7.28.4(@babel/core@7.29.6)
+      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.29.6)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.6)
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.6)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.6)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.29.6)
       core-js-compat: 3.46.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/types': 7.28.5
       esutils: 2.0.3
@@ -4355,7 +4357,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.28.5(supports-color@8.1.1)':
+  '@babel/traverse@7.28.5':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
@@ -4363,11 +4365,11 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.29.7(supports-color@8.1.1)':
+  '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -4375,7 +4377,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4394,17 +4396,17 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1(supports-color@8.1.1))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)':
     dependencies:
-      eslint: 8.57.1(supports-color@8.1.1)
+      eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/eslintrc@2.1.4(supports-color@8.1.1)':
+  '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -4419,10 +4421,10 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@humanwhocodes/config-array@0.13.0(supports-color@8.1.1)':
+  '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4450,12 +4452,12 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(supports-color@8.1.1)':
+  '@jest/core@29.7.0':
     dependencies:
       '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0(supports-color@8.1.1)
+      '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@8.1.1)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.19.24
       ansi-escapes: 4.3.2
@@ -4464,15 +4466,15 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.24)(supports-color@8.1.1)
+      jest-config: 29.7.0(@types/node@20.19.24)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0(supports-color@8.1.1)
-      jest-runner: 29.7.0(supports-color@8.1.1)
-      jest-runtime: 29.7.0(supports-color@8.1.1)
-      jest-snapshot: 29.7.0(supports-color@8.1.1)
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
@@ -4496,10 +4498,10 @@ snapshots:
     dependencies:
       jest-get-type: 29.6.3
 
-  '@jest/expect@29.7.0(supports-color@8.1.1)':
+  '@jest/expect@29.7.0':
     dependencies:
       expect: 29.7.0
-      jest-snapshot: 29.7.0(supports-color@8.1.1)
+      jest-snapshot: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4512,21 +4514,21 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  '@jest/globals@29.7.0(supports-color@8.1.1)':
+  '@jest/globals@29.7.0':
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0(supports-color@8.1.1)
+      '@jest/expect': 29.7.0
       '@jest/types': 29.6.3
       jest-mock: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/reporters@29.7.0(supports-color@8.1.1)':
+  '@jest/reporters@29.7.0':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@8.1.1)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
       '@types/node': 20.19.24
@@ -4536,9 +4538,9 @@ snapshots:
       glob: 7.2.3
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
+      istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1(supports-color@8.1.1)
+      istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.2.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -4574,12 +4576,12 @@ snapshots:
       jest-haste-map: 29.7.0
       slash: 3.0.0
 
-  '@jest/transform@29.7.0(supports-color@8.1.1)':
+  '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
+      babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -4707,10 +4709,10 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@rollup/plugin-babel@6.1.0(@babel/core@7.29.6(supports-color@8.1.1))(@types/babel__core@7.20.5)(rollup@4.52.5)(supports-color@8.1.1)':
+  '@rollup/plugin-babel@6.1.0(@babel/core@7.29.6)(@types/babel__core@7.20.5)(rollup@4.52.5)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-module-imports': 7.27.1
       '@rollup/pluginutils': 5.3.0(rollup@4.52.5)
     optionalDependencies:
       '@types/babel__core': 7.20.5
@@ -4824,35 +4826,35 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
+  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.2(typescript@5.9.3))':
     dependencies:
       conventional-changelog-angular: 8.1.0
       conventional-changelog-writer: 8.2.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.2.1
-      debug: 4.4.3(supports-color@8.1.1)
-      import-from-esm: 2.0.0(supports-color@8.1.1)
+      debug: 4.4.3
+      import-from-esm: 2.0.0
       lodash-es: 4.17.22
       micromatch: 4.0.8
-      semantic-release: 25.0.2(supports-color@8.1.1)(typescript@5.9.3)
+      semantic-release: 25.0.2(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/exec@7.1.0(semantic-release@25.0.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
+  '@semantic-release/exec@7.1.0(semantic-release@25.0.2(typescript@5.9.3))':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 3.1.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       execa: 9.6.1
       lodash-es: 4.17.22
       parse-json: 8.3.0
-      semantic-release: 25.0.2(supports-color@8.1.1)(typescript@5.9.3)
+      semantic-release: 25.0.2(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@12.0.2(semantic-release@25.0.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
+  '@semantic-release/github@12.0.2(semantic-release@25.0.2(typescript@5.9.3))':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
@@ -4860,22 +4862,22 @@ snapshots:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       dir-glob: 3.0.1
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       issue-parser: 7.0.1
       lodash-es: 4.17.22
       mime: 4.1.0
       p-filter: 4.1.0
-      semantic-release: 25.0.2(supports-color@8.1.1)(typescript@5.9.3)
+      semantic-release: 25.0.2(typescript@5.9.3)
       tinyglobby: 0.2.15
       undici: 7.18.2
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/npm@13.1.3(semantic-release@25.0.2(supports-color@8.1.1)(typescript@5.9.3))':
+  '@semantic-release/npm@13.1.3(semantic-release@25.0.2(typescript@5.9.3))':
     dependencies:
       '@actions/core': 2.0.2
       '@semantic-release/error': 4.0.0
@@ -4890,23 +4892,23 @@ snapshots:
       rc: 1.2.8
       read-pkg: 10.0.0
       registry-auth-token: 5.1.0
-      semantic-release: 25.0.2(supports-color@8.1.1)(typescript@5.9.3)
+      semantic-release: 25.0.2(typescript@5.9.3)
       semver: 7.7.3
       tempy: 3.1.0
 
-  '@semantic-release/release-notes-generator@14.1.0(semantic-release@25.0.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
+  '@semantic-release/release-notes-generator@14.1.0(semantic-release@25.0.2(typescript@5.9.3))':
     dependencies:
       conventional-changelog-angular: 8.1.0
       conventional-changelog-writer: 8.2.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.2.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       get-stream: 7.0.1
-      import-from-esm: 2.0.0(supports-color@8.1.1)
+      import-from-esm: 2.0.0
       into-stream: 7.0.0
       lodash-es: 4.17.22
       read-package-up: 11.0.0
-      semantic-release: 25.0.2(supports-color@8.1.1)(typescript@5.9.3)
+      semantic-release: 25.0.2(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -4990,16 +4992,16 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1(supports-color@8.1.1)
+      debug: 4.4.3
+      eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -5010,14 +5012,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1(supports-color@8.1.1)
+      debug: 4.4.3
+      eslint: 8.57.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5028,12 +5030,12 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
 
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1(supports-color@8.1.1)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -5042,11 +5044,11 @@ snapshots:
 
   '@typescript-eslint/types@6.21.0': {}
 
-  '@typescript-eslint/typescript-estree@6.21.0(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -5057,15 +5059,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@8.1.1)(typescript@5.9.3)
-      eslint: 8.57.1(supports-color@8.1.1)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      eslint: 8.57.1
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
@@ -5146,25 +5148,25 @@ snapshots:
 
   array-union@2.1.0: {}
 
-  babel-jest@29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1):
+  babel-jest@29.7.0(@babel/core@7.29.6):
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@jest/transform': 29.7.0(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
-      babel-preset-jest: 29.6.3(@babel/core@7.29.6(supports-color@8.1.1))
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.29.6)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-istanbul@6.1.1(supports-color@8.1.1):
+  babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
-      istanbul-lib-instrument: 5.2.1(supports-color@8.1.1)
+      istanbul-lib-instrument: 5.2.1
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -5176,54 +5178,54 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
-  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1):
+  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.29.6):
     dependencies:
       '@babel/compat-data': 7.28.5
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.6)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.6):
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.6)
       core-js-compat: 3.46.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1):
+  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.29.6):
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.6(supports-color@8.1.1)):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.6):
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.6)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.6)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.6)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.6)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.6)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.6)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.6)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.6)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.6)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.6)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.6)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.6)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.6)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.6)
 
-  babel-preset-jest@29.6.3(@babel/core@7.29.6(supports-color@8.1.1)):
+  babel-preset-jest@29.6.3(@babel/core@7.29.6):
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.6(supports-color@8.1.1))
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.6)
 
   balanced-match@1.0.2: {}
 
@@ -5422,13 +5424,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  create-jest@29.7.0(@types/node@20.19.24)(supports-color@8.1.1):
+  create-jest@29.7.0(@types/node@20.19.24):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.24)(supports-color@8.1.1)
+      jest-config: 29.7.0(@types/node@20.19.24)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -5447,11 +5449,9 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
-  debug@4.4.3(supports-color@8.1.1):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 8.1.1
 
   dedent@1.7.0: {}
 
@@ -5516,9 +5516,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@9.1.2(eslint@8.57.1(supports-color@8.1.1)):
+  eslint-config-prettier@9.1.2(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.1(supports-color@8.1.1)
+      eslint: 8.57.1
 
   eslint-scope@7.2.2:
     dependencies:
@@ -5527,20 +5527,20 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint@8.57.1(supports-color@8.1.1):
+  eslint@8.57.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/eslintrc': 2.1.4(supports-color@8.1.1)
+      '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.57.1
-      '@humanwhocodes/config-array': 0.13.0(supports-color@8.1.1)
+      '@humanwhocodes/config-array': 0.13.0
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.0
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -5837,17 +5837,17 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  http-proxy-agent@7.0.2(supports-color@8.1.1):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6(supports-color@8.1.1):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5864,9 +5864,9 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-from-esm@2.0.0(supports-color@8.1.1):
+  import-from-esm@2.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       import-meta-resolve: 4.2.0
     transitivePeerDependencies:
       - supports-color
@@ -5952,9 +5952,9 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@5.2.1(supports-color@8.1.1):
+  istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -5962,9 +5962,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-lib-instrument@6.0.3(supports-color@8.1.1):
+  istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -5978,9 +5978,9 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@4.0.1(supports-color@8.1.1):
+  istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -5999,10 +5999,10 @@ snapshots:
       jest-util: 29.7.0
       p-limit: 3.1.0
 
-  jest-circus@29.7.0(supports-color@8.1.1):
+  jest-circus@29.7.0:
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0(supports-color@8.1.1)
+      '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.19.24
@@ -6013,8 +6013,8 @@ snapshots:
       jest-each: 29.7.0
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
-      jest-runtime: 29.7.0(supports-color@8.1.1)
-      jest-snapshot: 29.7.0(supports-color@8.1.1)
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
       jest-util: 29.7.0
       p-limit: 3.1.0
       pretty-format: 29.7.0
@@ -6025,16 +6025,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.24)(supports-color@8.1.1):
+  jest-cli@29.7.0(@types/node@20.19.24):
     dependencies:
-      '@jest/core': 29.7.0(supports-color@8.1.1)
+      '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.24)(supports-color@8.1.1)
+      create-jest: 29.7.0(@types/node@20.19.24)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.24)(supports-color@8.1.1)
+      jest-config: 29.7.0(@types/node@20.19.24)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -6044,23 +6044,23 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.24)(supports-color@8.1.1):
+  jest-config@29.7.0(@types/node@20.19.24):
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-jest: 29.7.0(@babel/core@7.29.6)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0(supports-color@8.1.1)
+      jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-runner: 29.7.0(supports-color@8.1.1)
+      jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.8
@@ -6156,10 +6156,10 @@ snapshots:
 
   jest-regex-util@29.6.3: {}
 
-  jest-resolve-dependencies@29.7.0(supports-color@8.1.1):
+  jest-resolve-dependencies@29.7.0:
     dependencies:
       jest-regex-util: 29.6.3
-      jest-snapshot: 29.7.0(supports-color@8.1.1)
+      jest-snapshot: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6175,12 +6175,12 @@ snapshots:
       resolve.exports: 2.0.3
       slash: 3.0.0
 
-  jest-runner@29.7.0(supports-color@8.1.1):
+  jest-runner@29.7.0:
     dependencies:
       '@jest/console': 29.7.0
       '@jest/environment': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@8.1.1)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.19.24
       chalk: 4.1.2
@@ -6192,7 +6192,7 @@ snapshots:
       jest-leak-detector: 29.7.0
       jest-message-util: 29.7.0
       jest-resolve: 29.7.0
-      jest-runtime: 29.7.0(supports-color@8.1.1)
+      jest-runtime: 29.7.0
       jest-util: 29.7.0
       jest-watcher: 29.7.0
       jest-worker: 29.7.0
@@ -6201,14 +6201,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@29.7.0(supports-color@8.1.1):
+  jest-runtime@29.7.0:
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
-      '@jest/globals': 29.7.0(supports-color@8.1.1)
+      '@jest/globals': 29.7.0
       '@jest/source-map': 29.6.3
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@8.1.1)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.19.24
       chalk: 4.1.2
@@ -6221,24 +6221,24 @@ snapshots:
       jest-mock: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-snapshot: 29.7.0(supports-color@8.1.1)
+      jest-snapshot: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@29.7.0(supports-color@8.1.1):
+  jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/generator': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.6)
       '@babel/types': 7.29.7
       '@jest/expect-utils': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@8.1.1)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.6(supports-color@8.1.1))
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.6)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -6289,12 +6289,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.24)(supports-color@8.1.1):
+  jest@29.7.0(@types/node@20.19.24):
     dependencies:
-      '@jest/core': 29.7.0(supports-color@8.1.1)
+      '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.24)(supports-color@8.1.1)
+      jest-cli: 29.7.0(@types/node@20.19.24)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -6808,16 +6808,16 @@ snapshots:
 
   safe-buffer@5.1.2: {}
 
-  semantic-release@25.0.2(supports-color@8.1.1)(typescript@5.9.3):
+  semantic-release@25.0.2(typescript@5.9.3):
     dependencies:
-      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.2(typescript@5.9.3))
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 12.0.2(semantic-release@25.0.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
-      '@semantic-release/npm': 13.1.3(semantic-release@25.0.2(supports-color@8.1.1)(typescript@5.9.3))
-      '@semantic-release/release-notes-generator': 14.1.0(semantic-release@25.0.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
+      '@semantic-release/github': 12.0.2(semantic-release@25.0.2(typescript@5.9.3))
+      '@semantic-release/npm': 13.1.3(semantic-release@25.0.2(typescript@5.9.3))
+      '@semantic-release/release-notes-generator': 14.1.0(semantic-release@25.0.2(typescript@5.9.3))
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.0(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       env-ci: 11.2.0
       execa: 9.6.1
       figures: 6.1.0
@@ -6826,7 +6826,7 @@ snapshots:
       git-log-parser: 1.2.1
       hook-std: 4.0.0
       hosted-git-info: 9.0.2
-      import-from-esm: 2.0.0(supports-color@8.1.1)
+      import-from-esm: 2.0.0
       lodash-es: 4.17.22
       marked: 15.0.12
       marked-terminal: 7.3.0(marked@15.0.12)
@@ -7036,12 +7036,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.5(@babel/core@7.29.6(supports-color@8.1.1))(@jest/transform@29.7.0(supports-color@8.1.1))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.24)(supports-color@8.1.1))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.29.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.24))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@20.19.24)(supports-color@8.1.1)
+      jest: 29.7.0(@types/node@20.19.24)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -7050,10 +7050,10 @@ snapshots:
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@jest/transform': 29.7.0(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-jest: 29.7.0(@babel/core@7.29.6)
       jest-util: 29.7.0
 
   tslib@2.8.1: {}


### PR DESCRIPTION
## Summary

Adds `SharedStorage<V>` — a **group-writable single value with a rotatable writer set** — completing the JS SDK CRDT-type expansion (Phase 2b, the last CRDT type). Wraps the `js_crdt_shared_*` host functions from calimero-network/core#3340.

A `SharedStorage` cell holds one value that any member of its *writer set* may overwrite; writes converge last-write-wins, the writer set is managed at runtime, and the host rejects a non-writer's `set`/`rotateWriters`.

## What's here

| Layer | Change |
| --- | --- |
| `collections/SharedStorage.ts` | `set`/`get`, `writers`/`writableByMe`/`isFrozen`, `rotateWriters`, `fromId` rehydrate; hex or 32-byte writer keys |
| `env/bindings.ts` + `env/api.ts` | 8 `js_crdt_shared_*` externs + camelCase wrappers |
| `runtime/storage-wasm.ts` | 8 op wrappers (writer-gating surfaces host errors) |
| `runtime/deterministic-ids.ts` | SharedStorage-aware reassignment — carries the writer set/frozen flag across the deterministic-id re-open (the others re-open from id alone), so `@State` fields converge across nodes |
| `cli/builder/builder.c` | QuickJS shims (extern + wrapper + registration) for all 8 |
| `cli/abi/emitter.ts` | both type switches (logical inner value; `crdt_type: shared_storage`) |
| `__tests__/` | writer-set mock host fns + 20 unit tests |
| `examples/shared-storage/` | `TeamConfig` demo + single-node workflow |

## Test

- `pnpm build` green (sdk + cli).
- `pnpm test` green — **162/162** (20 new SharedStorage tests: read/write, writer gating, rotation add/remove, frozen, rehydration).

## Gating

The merobox e2e (`examples/shared-storage/workflows/shared-storage-js.yml`) is **gated on core#3340** — the `js_crdt_shared_*` host functions must be in the `merod:edge` image. It runs once #3340 merges and the image is rebuilt. Unit tests use mocks, so build/test are green now.

A concurrent multi-writer convergence workflow is deferred: adding a second node as a writer needs its public key decoded in-guest, which the SDK does not yet expose.

Draft until core#3340 merges → edge → e2e validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)