### PR TITLE
feat(sdk): reclaim orphaned collections in deterministic-id reassignment (closes #94)

### DIFF
--- a/packages/cli/builder/builder.c
+++ b/packages/cli/builder/builder.c
@@ -163,6 +163,7 @@ extern int32_t js_crdt_shared_writers(uint64_t cell_id_buffer_ptr, uint64_t regi
 extern int32_t js_crdt_shared_writable_by_me(uint64_t cell_id_buffer_ptr);
 extern int32_t js_crdt_shared_is_frozen(uint64_t cell_id_buffer_ptr);
 extern int32_t js_crdt_shared_rotate_writers(uint64_t cell_id_buffer_ptr, uint64_t writers_buffer_ptr);
+extern int32_t js_crdt_delete_collection(uint64_t id_buffer_ptr, uint64_t register_id);
 // PNCounter (signed PN-Counter). Provided by the node runtime (core#3318).
 extern int32_t js_crdt_pncounter_new(uint64_t register_id);
 extern int32_t js_crdt_pncounter_increment(uint64_t counter_id_buffer_ptr);
@@ -2851,6 +2852,26 @@ static JSValue js_env_crdt_shared_rotate_writers(JSContext *ctx, JSValueConst th
   return JS_NewInt32(ctx, result);
 }
 
+// Wrapper: js_crdt_delete_collection
+static JSValue js_env_crdt_delete_collection(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+  (void)this_val;
+  if (argc < 2) {
+    return JS_ThrowTypeError(ctx, "js_crdt_delete_collection expects id and register_id");
+  }
+  size_t id_len;
+  uint8_t *id_ptr = JSValueToUint8Array(ctx, argv[0], &id_len);
+  if (!id_ptr || id_len != 32) {
+    return JS_ThrowRangeError(ctx, "id must be 32 bytes");
+  }
+  int64_t register_id;
+  if (js_to_i64(ctx, argv[1], &register_id) < 0) {
+    return JS_EXCEPTION;
+  }
+  CalimeroBuffer id_buf = make_buffer(id_ptr, id_len);
+  int32_t result = js_crdt_delete_collection((uint64_t)&id_buf, (uint64_t)register_id);
+  return JS_NewInt32(ctx, result);
+}
+
 // Wrapper: ed25519_verify
 static JSValue js_ed25519_verify(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
   if (argc < 3) {
@@ -3040,6 +3061,7 @@ void js_add_calimero_host_functions(JSContext *ctx) {
   JS_SetPropertyStr(ctx, env, "js_crdt_shared_writable_by_me", JS_NewCFunction(ctx, js_env_crdt_shared_writable_by_me, "js_crdt_shared_writable_by_me", 1));
   JS_SetPropertyStr(ctx, env, "js_crdt_shared_is_frozen", JS_NewCFunction(ctx, js_env_crdt_shared_is_frozen, "js_crdt_shared_is_frozen", 1));
   JS_SetPropertyStr(ctx, env, "js_crdt_shared_rotate_writers", JS_NewCFunction(ctx, js_env_crdt_shared_rotate_writers, "js_crdt_shared_rotate_writers", 2));
+  JS_SetPropertyStr(ctx, env, "js_crdt_delete_collection", JS_NewCFunction(ctx, js_env_crdt_delete_collection, "js_crdt_delete_collection", 2));
 
   // Opt-in root merge + deterministic-id CRDT constructors
   JS_SetPropertyStr(ctx, env, "register_js_sdk_root_merge", JS_NewCFunction(ctx, js_register_js_sdk_root_merge, "register_js_sdk_root_merge", 0));

--- a/packages/sdk/src/__tests__/deterministic-id.test.ts
+++ b/packages/sdk/src/__tests__/deterministic-id.test.ts
@@ -1,7 +1,8 @@
 import './setup';
 import { computeCollectionId, computeEntryId, ROOT_ID } from '../utils/deterministic-id';
 import { assignDeterministicIds } from '../runtime/deterministic-ids';
-import { bytesToHex } from '../utils/hex';
+import { deleteCollection } from '../runtime/storage-wasm';
+import { bytesToHex, hexToBytes } from '../utils/hex';
 import { UnorderedMap } from '../collections/UnorderedMap';
 import { Vector } from '../collections/Vector';
 
@@ -54,6 +55,21 @@ describe('assignDeterministicIds', () => {
     expect((state.log as Vector<string>).id()).toBe(expectedLog);
     // Field was actually re-keyed off its original random id.
     expect((state.items as UnorderedMap<string, string>).id()).not.toBe(itemsRandomId);
+  });
+
+  it('deletes the orphaned random-id entity after re-keying', () => {
+    const map = new UnorderedMap<string, string>();
+    const randomId = map.id();
+    const state: Record<string, unknown> = { items: map };
+
+    assignDeterministicIds(state);
+
+    // The random-id orphan was reclaimed, so a delete now finds nothing.
+    expect(deleteCollection(hexToBytes(randomId))).toBe(false);
+    // Sanity: a live collection IS deletable (returns true), so the false above
+    // reflects a real deletion, not a broken probe.
+    const live = new UnorderedMap<string, string>();
+    expect(deleteCollection(hexToBytes(live.id()))).toBe(true);
   });
 
   it('is idempotent (a second pass leaves ids unchanged)', () => {

--- a/packages/sdk/src/__tests__/setup.ts
+++ b/packages/sdk/src/__tests__/setup.ts
@@ -500,6 +500,32 @@ function executorIsWriter(store: SharedCellStore): boolean {
     return 0;
   },
 
+  js_crdt_delete_collection: (id: Uint8Array, _register_id: bigint): number => {
+    const key = idToKey(id);
+    const stores = [
+      maps,
+      vectors,
+      sets,
+      counters,
+      lwwRegisters,
+      pnCounters,
+      rgas,
+      sortedMaps,
+      sortedSets,
+      authoredMaps,
+      authoredVectors,
+      sharedCells,
+    ];
+    let found = false;
+    for (const store of stores) {
+      if (store.has(key)) {
+        store.delete(key);
+        found = true;
+      }
+    }
+    return found ? 1 : 0;
+  },
+
   js_crdt_map_get: (mapId: Uint8Array, key: Uint8Array, _register_id: bigint): number => {
     const store = maps.get(idToKey(mapId));
     if (!store) {

--- a/packages/sdk/src/env/api.ts
+++ b/packages/sdk/src/env/api.ts
@@ -1107,6 +1107,10 @@ export function jsCrdtSharedRotateWriters(cellId: Uint8Array, writers: Uint8Arra
   return env.js_crdt_shared_rotate_writers(cellId, writers);
 }
 
+export function jsCrdtDeleteCollection(id: Uint8Array, register: bigint): number {
+  return env.js_crdt_delete_collection(id, register);
+}
+
 /**
  * Flush pending delta actions to the host.
  *

--- a/packages/sdk/src/env/bindings.ts
+++ b/packages/sdk/src/env/bindings.ts
@@ -199,6 +199,11 @@ export interface HostEnv {
   js_crdt_shared_is_frozen(cellId: Uint8Array): number;
   js_crdt_shared_rotate_writers(cellId: Uint8Array, writers: Uint8Array): number;
 
+  // Deletes a root-level collection entity by id and unlinks it from the root.
+  // Used to reclaim the random-id collection orphaned by deterministic-id
+  // reassignment. Returns 1 if deleted, 0 if none existed, -1 on error.
+  js_crdt_delete_collection(id: Uint8Array, register_id: bigint): number;
+
   // Context
   context_id(register_id: bigint): void;
   executor_id(register_id: bigint): void;

--- a/packages/sdk/src/runtime/deterministic-ids.ts
+++ b/packages/sdk/src/runtime/deterministic-ids.ts
@@ -34,6 +34,7 @@ import {
   sharedNewWithId,
   sharedWriters,
   sharedIsFrozen,
+  deleteCollection,
 } from './storage-wasm';
 
 type WithIdFn = (id: Uint8Array) => Uint8Array;
@@ -118,15 +119,25 @@ export function assignDeterministicIds(state: unknown): void {
     }
 
     // Create/re-open the entity at the deterministic id in the host, then swap
-    // the field to a collection wrapping that id. The previous random-id entity
-    // is orphaned (safe: fresh collections are empty). SharedStorage needs its
-    // writer set/frozen flag carried across; other collections re-open from id.
+    // the field to a collection wrapping that id. SharedStorage needs its writer
+    // set/frozen flag carried across; other collections re-open from id.
     if (isShared) {
       reopenSharedAt(snapshot.id, expectedId);
     } else {
       withId!(expectedId);
     }
     target[key] = instantiateCollection({ type: snapshot.type, id: expectedHex });
+
+    // Reclaim the random-id entity the field used to point at. This runs on
+    // fresh genesis state, so it is empty and the create+delete land in the same
+    // delta (every replica converges with no orphan). Best-effort: a benign
+    // leftover must never break init, so a cleanup failure is only logged.
+    try {
+      deleteCollection(hexToBytes(snapshot.id));
+    } catch (err) {
+      env.log(`[deterministic-ids] orphan cleanup skipped for '${key}': ${String(err)}`);
+    }
+
     env.log(
       `[deterministic-ids] field '${key}' (${snapshot.type}) -> ${expectedHex.slice(0, 16)}…`
     );

--- a/packages/sdk/src/runtime/storage-wasm.ts
+++ b/packages/sdk/src/runtime/storage-wasm.ts
@@ -111,6 +111,7 @@ import {
   jsCrdtSharedWritableByMe,
   jsCrdtSharedIsFrozen,
   jsCrdtSharedRotateWriters,
+  jsCrdtDeleteCollection,
 } from '../env/api';
 
 const REGISTER_ID = 0n;
@@ -1667,4 +1668,19 @@ export function sharedRotateWriters(cellId: Uint8Array, writers: Uint8Array): vo
   if (status < 0) {
     decodeError('sharedRotateWriters');
   }
+}
+
+/**
+ * Delete a root-level collection entity by id and unlink it from the root.
+ * Returns `true` if an entity was deleted, `false` if none existed at that id
+ * (idempotent). Used to reclaim the random-id collection orphaned when a
+ * top-level `@State` field is re-opened at its deterministic id.
+ */
+export function deleteCollection(id: Uint8Array): boolean {
+  ensureCollectionId(id, 'id');
+  const status = Number(jsCrdtDeleteCollection(id, REGISTER_ID));
+  if (status < 0) {
+    decodeError('deleteCollection');
+  }
+  return status === 1;
 }


### PR DESCRIPTION
## Summary

Closes #94. Wires the `js_crdt_delete_collection` host function (calimero-network/core#3343, merged) into the JS SDK so the **orphaned random-id collection** left by deterministic-id reassignment is reclaimed.

The JS SDK creates each top-level `@State` collection at a random id, then re-opens it at a deterministic id (so replicas address the same entity). The original random-id entity was left orphaned — a fresh, empty collection. This PR deletes it right after the swap.

## What's here

- `env/bindings.ts` + `env/api.ts` + `runtime/storage-wasm.ts` — `deleteCollection(id)` op wrapper.
- `cli/builder/builder.c` — QuickJS shim for `js_crdt_delete_collection`.
- `runtime/deterministic-ids.ts` — after each field is re-keyed to its deterministic id, delete the random-id orphan. **Best-effort**: a benign leftover must never break init, so a cleanup failure is only logged.
- tests — host-fn mock + a `deterministic-id` test asserting the orphan is gone (and a live collection is still deletable, so the probe is real).

## Convergence safety

The delete runs only during deterministic-id reassignment, which happens on **fresh genesis state** — the create and delete land in the **same genesis delta**, so every replica converges with no orphan. A hydrated (joining) node has its field already at the deterministic id and skips reassignment (the `snapshot.id === expectedHex` guard), so it never issues a standalone delete.

## Test

- `pnpm build` + `pnpm test` green — **172 tests**.
- The 2-node example workflows in the merobox suite (which converge `@State` collection fields across nodes) exercise this end-to-end and must stay green — the node-level proof that the orphan-delete doesn't diverge replicas.

**Draft** until the `merod:edge` image is rebuilt with #3343 (the merobox job needs the new host fn); the image is rebuilding on the #3343 merge now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)